### PR TITLE
Support plain message connection instead of websocket for lsp

### DIFF
--- a/integration/standalone/src/app.ts
+++ b/integration/standalone/src/app.ts
@@ -66,7 +66,9 @@ async function initialize(connectionProvider: MessageConnection): Promise<void> 
     .then(() => {
       actionDispatcher.onceModelInitialized().finally(() => {
         MonacoUtil.initStandalone(editorWorker).then(() => MonacoEditorUtil.initMonaco(reactMonaco, theme));
-        actionDispatcher.dispatch(EnableInscriptionAction.create({ server: webSocketBase, inscriptionContext: { app, pmv } }));
+        actionDispatcher.dispatch(
+          EnableInscriptionAction.create({ connection: { server: webSocketBase }, inscriptionContext: { app, pmv } })
+        );
         if (selectElementIds) {
           const elementIds = selectElementIds.split(NavigationTarget.ELEMENT_IDS_SEPARATOR);
           actionDispatcher.dispatch(SelectAction.create({ selectedElementsIDs: elementIds }));

--- a/packages/inscription/src/inscription/action.ts
+++ b/packages/inscription/src/inscription/action.ts
@@ -1,9 +1,10 @@
 import { Action } from '@eclipse-glsp/client';
 import { InscriptionContext } from '@axonivy/inscription-protocol';
+import { MessageConnection } from '@axonivy/inscription-core';
 
 export interface EnableInscriptionAction extends Action {
   kind: typeof EnableInscriptionAction.KIND;
-  server?: string;
+  connection?: { server?: string; inscription?: MessageConnection; ivyScript?: MessageConnection };
   inscriptionContext?: InscriptionContext;
 }
 
@@ -14,7 +15,7 @@ export namespace EnableInscriptionAction {
     return Action.hasKind(object, KIND);
   }
 
-  export function create(options: { server?: string; inscriptionContext?: InscriptionContext }): EnableInscriptionAction {
+  export function create(options: Omit<EnableInscriptionAction, 'kind'>): EnableInscriptionAction {
     return { kind: KIND, ...options };
   }
 }

--- a/packages/inscription/src/inscription/inscription-ui.tsx
+++ b/packages/inscription/src/inscription/inscription-ui.tsx
@@ -101,9 +101,18 @@ export class InscriptionUi extends AbstractUIExtension implements IActionHandler
 
   async startInscriptionClient() {
     const model = this.editorContext.modelRoot;
-    const webSocketAddress = this.action?.server ?? GArgument.getString(model, 'webSocket') ?? 'ws://localhost:8081/';
-    await IvyScriptLanguage.startWebSocketClient(webSocketAddress);
-    const client = await InscriptionClientJsonRpc.startWebSocketClient(webSocketAddress);
+    const webSocketAddress = this.action?.connection?.server ?? GArgument.getString(model, 'webSocket') ?? 'ws://localhost:8081/';
+    if (this.action?.connection?.ivyScript) {
+      await IvyScriptLanguage.startClient(this.action?.connection?.ivyScript);
+    } else {
+      await IvyScriptLanguage.startWebSocketClient(webSocketAddress);
+    }
+    let client: InscriptionClient;
+    if (this.action?.connection?.inscription) {
+      client = await InscriptionClientJsonRpc.startClient(this.action.connection.inscription);
+    } else {
+      client = await InscriptionClientJsonRpc.startWebSocketClient(webSocketAddress);
+    }
     await client.initialize();
     return client;
   }


### PR DESCRIPTION
Support plain MessageConnection instead of create web socket connection for the inscription lsp's, e.g. by create the websocket MessageConnection for the inscription here instead inside of the inscription ui:
```ts
const webSocketUrl = ConnectionUtil.buildWebSocketUrl(webSocketBase, '/ivy-inscription-lsp');
ConnectionUtil.createWebSocketConnection(webSocketUrl).then(connection => {
  actionDispatcher.dispatch(
    EnableInscriptionAction.create({
      connection: { server: webSocketBase, inscription: connection },
      inscriptionContext: { app, pmv }
    })
  );
});
```