### PR TITLE
XIVY-16581 Everybody is no longer needed as default role in case of not-anonymous for starts

### DIFF
--- a/packages/inscription-view/src/components/parts/common/permission/Permission.tsx
+++ b/packages/inscription-view/src/components/parts/common/permission/Permission.tsx
@@ -25,7 +25,7 @@ export const Permission = ({ anonymousFieldActive, config, defaultConfig, update
       )}
       {(!anonymousFieldActive || (anonymousFieldActive && !config.anonymous)) && (
         <PathFieldset label={t('common.label.roles')} path='roles'>
-          <MultipleRoleSelect value={config.roles} onChange={change => updatePermission('roles', change)} />
+          <MultipleRoleSelect value={config.roles} onChange={change => updatePermission('roles', change)} defaultRoles={[]} />
         </PathFieldset>
       )}
       <PathFieldset label={t('label.validationError')} path='error'>

--- a/packages/inscription-view/src/components/parts/common/responsible/ResponsibleSelect.tsx
+++ b/packages/inscription-view/src/components/parts/common/responsible/ResponsibleSelect.tsx
@@ -21,6 +21,7 @@ const Responsible = ({ selectedType, ...props }: ResponsibleMemberProps) => {
         <MultipleRoleSelect
           value={props.responsible?.roles ?? []}
           onChange={change => props.updateResponsible('roles', change)}
+          defaultRoles={['Everybody']}
           showTaskRoles={true}
         />
       );

--- a/packages/inscription-view/src/components/parts/common/role/MultipleRoleSelect.test.tsx
+++ b/packages/inscription-view/src/components/parts/common/role/MultipleRoleSelect.test.tsx
@@ -13,7 +13,7 @@ describe('MultipleRoleSelect', () => {
         { id: 'Teamleader', label: '', children: [] }
       ]
     };
-    customRender(<MultipleRoleSelect value={roles} onChange={() => {}} />, {
+    customRender(<MultipleRoleSelect value={roles} onChange={() => {}} defaultRoles={['Everybody']} />, {
       wrapperProps: { meta: { roleTree } }
     });
   }

--- a/packages/inscription-view/src/components/parts/common/role/MultipleRoleSelect.tsx
+++ b/packages/inscription-view/src/components/parts/common/role/MultipleRoleSelect.tsx
@@ -9,15 +9,16 @@ import Tags from '../../../widgets/tag/Tags';
 
 type MultipleRoleSelectProps = {
   value: string[];
+  defaultRoles: string[];
   onChange: (change: string[]) => void;
   showTaskRoles?: boolean;
 };
 
-const MultipleRoleSelect = ({ value, onChange, showTaskRoles }: MultipleRoleSelectProps) => {
+const MultipleRoleSelect = ({ value, defaultRoles, onChange, showTaskRoles }: MultipleRoleSelectProps) => {
   const { roles: roleItems } = useRoles(showTaskRoles);
   const browser = useBrowser();
   const path = usePath();
-  const selectedRoles = value.length > 0 ? value : ['Everybody'];
+  const selectedRoles = value.length > 0 ? value : defaultRoles;
 
   return (
     <Flex direction='row' alignItems='center' gap={1} className='role-select'>


### PR DESCRIPTION
behavior discussed with cst:

![image](https://github.com/user-attachments/assets/98bb15a5-01be-4574-a6d0-6a678ccb1dac)

if anonymous is not checked. everybody is no longer needed. this will be also removed on the UI now.