### PR TITLE
XIVY-16719 Set overflow hidden for InputBadge component

### DIFF
--- a/packages/inscription-view/src/components/widgets/code-editor/MacroInput.tsx
+++ b/packages/inscription-view/src/components/widgets/code-editor/MacroInput.tsx
@@ -35,7 +35,7 @@ export const MacroInput = ({ value, onChange, browsers, ...props }: MacroInputPr
         <InputBadge
           badgeProps={badgePropsExpression}
           value={value}
-          style={{ overflow: 'hidden' }}
+          // style={{ overflow: 'hidden' }}
           tabIndex={0}
           {...inputProps}
           {...props}

--- a/packages/inscription-view/src/components/widgets/code-editor/MacroInput.tsx
+++ b/packages/inscription-view/src/components/widgets/code-editor/MacroInput.tsx
@@ -32,7 +32,14 @@ export const MacroInput = ({ value, onChange, browsers, ...props }: MacroInputPr
           <Browser {...browser} types={browsers} accept={modifyEditor} location={path} />
         </>
       ) : (
-        <InputBadge badgeProps={badgePropsExpression} value={value} tabIndex={0} {...inputProps} {...props} />
+        <InputBadge
+          badgeProps={badgePropsExpression}
+          value={value}
+          style={{ overflow: 'hidden' }}
+          tabIndex={0}
+          {...inputProps}
+          {...props}
+        />
       )}
     </div>
   );

--- a/packages/inscription-view/src/components/widgets/combobox/Combobox.tsx
+++ b/packages/inscription-view/src/components/widgets/combobox/Combobox.tsx
@@ -123,7 +123,7 @@ const Combobox = <T extends ComboboxItem>({
               ) : null}
             </>
           ) : (
-            <InputBadge badgeProps={badgePropsExpression} value={value} tabIndex={0} {...inputProps} />
+            <InputBadge badgeProps={badgePropsExpression} value={value} tabIndex={0} style={{ overflow: 'hidden' }} {...inputProps} />
           )
         ) : (
           <Input {...getInputProps()} {...inputProps} {...props} />

--- a/packages/inscription-view/src/components/widgets/combobox/Combobox.tsx
+++ b/packages/inscription-view/src/components/widgets/combobox/Combobox.tsx
@@ -123,7 +123,7 @@ const Combobox = <T extends ComboboxItem>({
               ) : null}
             </>
           ) : (
-            <InputBadge badgeProps={badgePropsExpression} value={value} tabIndex={0} style={{ overflow: 'hidden' }} {...inputProps} />
+            <InputBadge badgeProps={badgePropsExpression} value={value} tabIndex={0} {...inputProps} />
           )
         ) : (
           <Input {...getInputProps()} {...inputProps} {...props} />


### PR DESCRIPTION
Had to set overflow hidden, because within the ui-components the InputBadge component set overflowX to auto, which caused the horizontal scrollbar to be displayed.
See: https://1ivy.atlassian.net/browse/XIVY-16808