### PR TITLE
Reset remove reset inscrption

### DIFF
--- a/packages/editor/src/translation/process-editor/de.json
+++ b/packages/editor/src/translation/process-editor/de.json
@@ -149,6 +149,7 @@
     "process": "Prozess",
     "removeRow": "Zeile entfernen",
     "request": "Anfrage",
+    "reset": "{{name}} zurücksetzen",
     "responsible": "Verantwortlich",
     "timeout": "Zeitüberschreitung",
     "URL": "URL",

--- a/packages/editor/src/translation/process-editor/en.json
+++ b/packages/editor/src/translation/process-editor/en.json
@@ -149,6 +149,7 @@
     "process": "Process",
     "removeRow": "Remove row",
     "request": "Request",
+    "reset": "Reset {{name}}",
     "responsible": "Responsible",
     "timeout": "Timeout",
     "URL": "URL",

--- a/packages/inscription-view/src/App.tsx
+++ b/packages/inscription-view/src/App.tsx
@@ -21,11 +21,16 @@ import { useTranslation } from 'react-i18next';
 function App({ outline, app, pmv, pid }: InscriptionElementContext & InscriptionOutlineProps) {
   const { t } = useTranslation();
   const [context, setContext] = useState({ app, pmv, pid });
-  const [initData, setInitData] = useState<Record<string, ElementData>>({});
+  const [initData, setInitData] = useState<ElementData | undefined>();
   const [showOutline, setShowOutline] = useState(false);
 
   useEffect(() => {
-    setContext({ app, pmv, pid });
+    setContext(old => {
+      if (old.pid !== pid) {
+        setInitData(undefined);
+      }
+      return { app, pmv, pid };
+    });
   }, [app, pmv, pid]);
 
   const client = useClient();
@@ -56,13 +61,10 @@ function App({ outline, app, pmv, pid }: InscriptionElementContext & Inscription
   });
 
   useEffect(() => {
-    if (isSuccess && !initData[context.pid]) {
-      setInitData(initData => {
-        initData[context.pid] = data.data;
-        return initData;
-      });
+    if (isSuccess && initData === undefined) {
+      setInitData(data.data);
     }
-  }, [context.pid, data, initData, isSuccess]);
+  }, [isSuccess, data, initData]);
 
   const { data: validations } = useQuery({
     queryKey: queryKeys.validation(context),
@@ -121,7 +123,7 @@ function App({ outline, app, pmv, pid }: InscriptionElementContext & Inscription
               data: data.data,
               setData: mutation.mutate,
               defaultData: data.defaults,
-              initData: initData[context.pid] ?? data.data,
+              initData: initData ?? data.data,
               validations
             }}
           >

--- a/packages/inscription-view/src/components/editors/InscriptionEditor.tsx
+++ b/packages/inscription-view/src/components/editors/InscriptionEditor.tsx
@@ -16,6 +16,7 @@ import { useEditorContext } from '../../context/useEditorContext';
 import { useAction } from '../../context/useAction';
 import { useTranslation } from 'react-i18next';
 import { useKnownHotkeys } from '../../utils/useKnownHotkeys';
+import { usePartDirty } from './part/usePart';
 
 export type KnownEditor = { editor: ReactNode; icon?: IvyIcons };
 
@@ -37,7 +38,8 @@ const inscriptionEditor = (type?: ElementType): ReactNode => {
 const Header = ({ children }: { children?: ReactNode }) => {
   const { t } = useTranslation();
   const { data } = useGeneralData();
-  const { validations } = useDataContext();
+  const { data: tabData, initData, setData, validations } = useDataContext();
+  const dirty = usePartDirty(initData, tabData);
   const tabValidations = validations.filter(val => val.path.length === 0);
   const { type } = useEditorContext();
   const helpUrl = type.helpUrl;
@@ -49,6 +51,14 @@ const Header = ({ children }: { children?: ReactNode }) => {
   return (
     <>
       <SidebarHeader title={title} icon={icon} className='header'>
+        {dirty && (
+          <Button
+            icon={IvyIcons.Undo}
+            onClick={() => setData(() => initData)}
+            title={t('label.reset', { name: title })}
+            aria-label={t('label.reset', { name: title })}
+          />
+        )}
         {children}
         {helpUrl !== undefined && helpUrl !== '' && (
           <Button icon={IvyIcons.Help} onClick={() => action(helpUrl)} title={openHelp.label} aria-label={openHelp.label} />

--- a/packages/inscription-view/src/components/editors/part/usePart.ts
+++ b/packages/inscription-view/src/components/editors/part/usePart.ts
@@ -33,6 +33,12 @@ export function usePartState(defaultData: unknown, data: unknown, validations: V
   return { state, validations };
 }
 
+export function usePartDirty(initData: unknown, data: unknown): boolean {
+  return useMemo<boolean>(() => {
+    return !deepEqual(data, initData);
+  }, [data, initData]);
+}
+
 const INSCRIPTIONTAB_STORAGE_KEY = 'process-inscription-tab';
 
 export const useInscriptionTabState = (parts: Array<PartProps>) => {

--- a/playwright/tests/inscription/mock/reset.spec.ts
+++ b/playwright/tests/inscription/mock/reset.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+import { openMockInscription } from '../../page-objects/inscription/inscription-view';
+
+test.describe('Reset tab', () => {
+  test('reset button', async ({ page }) => {
+    const inscriptionView = await openMockInscription(page);
+    const general = inscriptionView.inscriptionTab('General');
+    await general.open();
+
+    const resetBtn = inscriptionView.reset();
+    await expect(resetBtn).toBeHidden();
+    const desc = general.textArea({ label: 'Description' });
+    await desc.fill('bla');
+    await expect(resetBtn).toBeVisible();
+
+    const task = inscriptionView.inscriptionTab('Task');
+    await task.open();
+
+    const name = task.macroInput('Name');
+    await name.fill('bli');
+
+    await resetBtn.click();
+    await name.expectValue('user task');
+
+    await general.open();
+    await desc.expectValue('test desc');
+  });
+});

--- a/playwright/tests/page-objects/inscription/inscription-view.ts
+++ b/playwright/tests/page-objects/inscription/inscription-view.ts
@@ -68,6 +68,10 @@ export class Inscription {
     await expect(this.root).toHaveAttribute('data-mutation-state', 'success');
   }
 
+  reset() {
+    return this.page.locator('button[aria-label^="Reset"]');
+  }
+
   async waitForView() {
     await expect(this.root).toBeVisible();
   }

--- a/playwright/tests/standalone/inscription/view.spec.ts
+++ b/playwright/tests/standalone/inscription/view.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { ProcessEditor } from '../../page-objects/editor/process-editor';
+import type { Inscription } from '../../page-objects/inscription/inscription-view';
 
 test('elements', async ({ page }) => {
   const processEditor = await ProcessEditor.openProcess(page);
@@ -13,6 +14,24 @@ test('elements', async ({ page }) => {
   await processEditor.resetSelection();
   await view.expectHeaderText(/Business Process/);
   await view.expectClosed();
+});
+
+test('undo', async ({ page }) => {
+  const processEditor = await ProcessEditor.openProcess(page);
+  const start = processEditor.startElement;
+  const view = await start.inscribe();
+  await changeName(view, 'start', 'hello');
+
+  await processEditor.endElement.select();
+  const { part, input } = await changeName(view, '', 'world');
+  const resetBtn = view.reset();
+
+  await resetBtn.click();
+  await input.expectValue('');
+  await start.select();
+  await part.open();
+  await resetBtn.click();
+  await input.expectValue('start');
 });
 
 test('ivyscript lsp', async ({ page }) => {
@@ -71,3 +90,14 @@ test('web service auth link', async ({ page }) => {
   await wsStart.expectNotSelected();
   await view.expectHeaderText('Web Service Process');
 });
+
+async function changeName(view: Inscription, oldValue: string, value: string) {
+  const part = view.inscriptionTab('General');
+  await part.open();
+  const section = part.section('Name / Description');
+  await section.open();
+  const input = section.textArea({ label: 'Display name' });
+  await input.expectValue(oldValue);
+  await input.fill(value);
+  return { part, input };
+}

--- a/playwright/tests/standalone/inscription/view.spec.ts
+++ b/playwright/tests/standalone/inscription/view.spec.ts
@@ -20,18 +20,23 @@ test('undo', async ({ page }) => {
   const processEditor = await ProcessEditor.openProcess(page);
   const start = processEditor.startElement;
   const view = await start.inscribe();
+  const resetBtn = view.reset();
+  await expect(resetBtn).toBeHidden();
   await changeName(view, 'start', 'hello');
+  await expect(resetBtn).toBeVisible();
 
   await processEditor.endElement.select();
   const { part, input } = await changeName(view, '', 'world');
-  const resetBtn = view.reset();
 
   await resetBtn.click();
   await input.expectValue('');
   await start.select();
+  await expect(resetBtn).toBeHidden();
   await part.open();
+  await changeName(view, 'hello', 'start');
+  await expect(resetBtn).toBeVisible();
   await resetBtn.click();
-  await input.expectValue('start');
+  await input.expectValue('hello');
 });
 
 test('ivyscript lsp', async ({ page }) => {


### PR DESCRIPTION
In the first commit, I reverted the removal of the inscription reset logic. In the second commit, I refined the reset behavior: now, initData is updated as soon as you switch to a new element. This ensures that reset only undoes changes made during the current editing session of that element, rather than reverting to an outdated state from previous edits.

![reset](https://github.com/user-attachments/assets/cdcbbbda-36c7-4704-959c-6467dbcc4913)
