### PR TITLE
XIVY-17023 Wrap Cache-Mode into its own Collapsible

### DIFF
--- a/packages/editor/src/translation/process-editor/de.json
+++ b/packages/editor/src/translation/process-editor/de.json
@@ -195,7 +195,8 @@
         "invalidate": "Cache ungültig machen",
         "invalidateMode": "Verwenden Sie diese Option, wenn Sie eine Operation aufrufen, die Daten ändert",
         "noCache": "Nicht zwischenspeichern",
-        "noCacheMode": "Verwendet kein Caching."
+        "noCacheMode": "Verwendet kein Caching.",
+        "title": "Modus"
       },
       "scope": "Scope",
       "scopeMode": {

--- a/packages/editor/src/translation/process-editor/en.json
+++ b/packages/editor/src/translation/process-editor/en.json
@@ -195,7 +195,8 @@
         "invalidate": "Invalidate Cache",
         "invalidateMode": "Use if you call an operation that modifies data",
         "noCache": "Do not cache",
-        "noCacheMode": "Does not use caching at all."
+        "noCacheMode": "Does not use caching at all.",
+        "title": "Mode"
       },
       "scope": "Scope",
       "scopeMode": {

--- a/packages/inscription-view/src/components/parts/cache/CachePart.tsx
+++ b/packages/inscription-view/src/components/parts/cache/CachePart.tsx
@@ -29,20 +29,22 @@ const CachePart = () => {
   const { config, update, updateGroup, updateEntry } = useCacheData();
   return (
     <PathContext path='cache'>
-      <Radio
-        value={config.cache.mode}
-        onChange={change => update('mode', change)}
-        items={[
-          { label: t('part.cache.mode.noCache'), value: 'DO_NOT_CACHE', description: t('part.cache.mode.noCacheMode') },
-          { label: t('part.cache.mode.cache'), value: 'CACHE', description: t('part.cache.mode.cacheDesc') },
-          {
-            label: t('part.cache.mode.invalidate'),
-            value: 'INVALIDATE_CACHE',
-            description: t('part.cache.mode.invalidateMode')
-          }
-        ]}
-        style={{ paddingInline: 'var(--size-2)' }}
-      />
+      <Collapsible label={t('part.cache.mode.title')} defaultOpen={true}>
+        <Radio
+          value={config.cache.mode}
+          onChange={change => update('mode', change)}
+          items={[
+            { label: t('part.cache.mode.noCache'), value: 'DO_NOT_CACHE', description: t('part.cache.mode.noCacheMode') },
+            { label: t('part.cache.mode.cache'), value: 'CACHE', description: t('part.cache.mode.cacheDesc') },
+            {
+              label: t('part.cache.mode.invalidate'),
+              value: 'INVALIDATE_CACHE',
+              description: t('part.cache.mode.invalidateMode')
+            }
+          ]}
+          style={{ paddingInline: 'var(--size-2)' }}
+        />
+      </Collapsible>
       {config.cache.mode !== 'DO_NOT_CACHE' && (
         <>
           <Collapsible label={t('part.cache.scope')} defaultOpen={true}>


### PR DESCRIPTION
Not sure why there was no collabsible before
before:
![grafik](https://github.com/user-attachments/assets/fe599264-9c2f-4218-99e2-7a70222e98aa)

after:
![grafik](https://github.com/user-attachments/assets/71167be4-1c6d-4baf-9840-f5941c659e09)
