### PR TITLE
XIVY-17023 Add default Open on most important Collapsible per Tab

### DIFF
--- a/packages/editor/src/translation/process-editor/de.json
+++ b/packages/editor/src/translation/process-editor/de.json
@@ -115,7 +115,6 @@
       "color": "Farbe",
       "delete": "Löschen",
       "description": "Beschreibung",
-      "details": "Details",
       "mapping": "Zuordnung",
       "name": "Name",
       "roles": "Rollen",

--- a/packages/editor/src/translation/process-editor/en.json
+++ b/packages/editor/src/translation/process-editor/en.json
@@ -115,7 +115,6 @@
       "color": "Color",
       "delete": "Delete",
       "description": "Description",
-      "details": "Details",
       "mapping": "Mapping",
       "name": "Name",
       "roles": "Roles",

--- a/packages/inscription-view/src/components/editors/activity/interface.tsx
+++ b/packages/inscription-view/src/components/editors/activity/interface.tsx
@@ -55,10 +55,10 @@ const RestEditor = memo(() => {
 const EMailEditor = memo(() => {
   const name = useGeneralPart();
   const header = useMailHeaderPart();
-  const error = useMailErrorPart();
   const content = useMailMessagePart();
   const attachment = useMailAttachmentPart();
-  return <Part parts={[name, header, error, content, attachment]} />;
+  const error = useMailErrorPart();
+  return <Part parts={[name, header, content, attachment, error]} />;
 });
 
 const ProgramInterfaceEditor = memo(() => {

--- a/packages/inscription-view/src/components/editors/activity/workflow.tsx
+++ b/packages/inscription-view/src/components/editors/activity/workflow.tsx
@@ -30,7 +30,7 @@ const UserTaskEditor = memo(() => {
 
 const ScriptEditor = memo(() => {
   const name = useGeneralPart();
-  const output = useOutputPart({ showSudo: true, additionalBrowsers: ['cms'] });
+  const output = useOutputPart({ showSudo: true, additionalBrowsers: ['cms'], defaultOpenCode: true });
   return <Part parts={[name, output]} />;
 });
 

--- a/packages/inscription-view/src/components/editors/event/start.tsx
+++ b/packages/inscription-view/src/components/editors/event/start.tsx
@@ -18,7 +18,7 @@ import { useTriggerPart } from '../../parts/trigger/TriggerPart';
 
 const RequestStartEditor = memo(() => {
   const name = useGeneralPart();
-  const start = useStartPart();
+  const start = useStartPart({ signatureDefaultOpen: true });
   const request = useRequestPart();
   const trigger = useTriggerPart();
   const task = useTaskPart({ type: 'request' });

--- a/packages/inscription-view/src/components/parts/call/CallMapping.tsx
+++ b/packages/inscription-view/src/components/parts/call/CallMapping.tsx
@@ -23,9 +23,11 @@ const CallMapping = ({ variableInfo }: { variableInfo: VariableInfo }) => {
     <PathContext path='call'>
       <MappingPart
         data={config.call.map}
+        defaultData={defaultConfig.call.map}
         variableInfo={variableInfo}
         onChange={change => update('map', change)}
         browsers={['attr', 'func', 'type']}
+        defaultOpen={true}
       />
       <PathCollapsible
         label={t('label.code')}

--- a/packages/inscription-view/src/components/parts/call/dialog/DialogCallPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/call/dialog/DialogCallPart.test.tsx
@@ -22,8 +22,8 @@ describe('DialogCallPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Dialog');
-    await CollapsableUtil.assertClosed('Mapping');
+    await CollapsableUtil.assertOpen('Dialog');
+    await CollapsableUtil.assertOpen('Mapping');
     await CollapsableUtil.assertClosed('Code');
   });
 

--- a/packages/inscription-view/src/components/parts/call/dialog/DialogCallPart.tsx
+++ b/packages/inscription-view/src/components/parts/call/dialog/DialogCallPart.tsx
@@ -37,7 +37,7 @@ export function useDialogCallPart(options?: { offline?: boolean }): PartProps {
 
 const DialogCallPart = ({ offline }: { offline?: boolean }) => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update } = useDialogCallData();
+  const { config, update } = useDialogCallData();
 
   const { context } = useEditorContext();
   const { data: startItems } = useMeta('meta/start/dialogs', { context, supportOffline: offline ?? false }, []);
@@ -51,12 +51,7 @@ const DialogCallPart = ({ offline }: { offline?: boolean }) => {
   const createDialog: FieldsetControl = { label: t('part.call.dialog.create'), icon: IvyIcons.Plus, action: () => action() };
   return (
     <>
-      <PathCollapsible
-        label={t('part.call.dialog.title')}
-        controls={[createDialog]}
-        defaultOpen={config.dialog !== defaultConfig.dialog}
-        path='dialog'
-      >
+      <PathCollapsible label={t('part.call.dialog.title')} controls={[createDialog]} defaultOpen={true} path='dialog'>
         <ValidationFieldset>
           <CallSelect
             start={config.dialog}

--- a/packages/inscription-view/src/components/parts/call/sub/SubCallPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/call/sub/SubCallPart.test.tsx
@@ -22,8 +22,8 @@ describe('SubCallPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Process start');
-    await CollapsableUtil.assertClosed('Mapping');
+    await CollapsableUtil.assertOpen('Process start');
+    await CollapsableUtil.assertOpen('Mapping');
     await CollapsableUtil.assertClosed('Code');
   });
 

--- a/packages/inscription-view/src/components/parts/call/sub/SubCallPart.tsx
+++ b/packages/inscription-view/src/components/parts/call/sub/SubCallPart.tsx
@@ -37,7 +37,7 @@ export function useSubCallPart(): PartProps {
 
 const SubCallPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update } = useProcessCallData();
+  const { config, update } = useProcessCallData();
 
   const { context } = useEditorContext();
   const { data: startItems } = useMeta('meta/start/calls', context, []);
@@ -51,12 +51,7 @@ const SubCallPart = () => {
   const createProcess: FieldsetControl = { label: t('part.call.sub.create'), icon: IvyIcons.Plus, action: () => action() };
   return (
     <>
-      <PathCollapsible
-        label={t('part.call.processStart')}
-        controls={[createProcess]}
-        defaultOpen={config.processCall !== defaultConfig.processCall}
-        path='processCall'
-      >
+      <PathCollapsible label={t('part.call.processStart')} controls={[createProcess]} defaultOpen={true} path='processCall'>
         <ValidationFieldset>
           <CallSelect
             start={config.processCall}

--- a/packages/inscription-view/src/components/parts/call/trigger/TriggerCallPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/call/trigger/TriggerCallPart.test.tsx
@@ -22,8 +22,8 @@ describe('TriggerCallPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Process start');
-    await CollapsableUtil.assertClosed('Mapping');
+    await CollapsableUtil.assertOpen('Process start');
+    await CollapsableUtil.assertOpen('Mapping');
     await CollapsableUtil.assertClosed('Code');
   });
 

--- a/packages/inscription-view/src/components/parts/call/trigger/TriggerCallPart.tsx
+++ b/packages/inscription-view/src/components/parts/call/trigger/TriggerCallPart.tsx
@@ -37,7 +37,7 @@ export function useTriggerCallPart(): PartProps {
 
 const TriggerCallPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update } = useProcessCallData();
+  const { config, update } = useProcessCallData();
 
   const { context } = useEditorContext();
   const { data: startItems } = useMeta('meta/start/triggers', context, []);
@@ -51,12 +51,7 @@ const TriggerCallPart = () => {
   const createProcess: FieldsetControl = { label: t('part.call.trigger.create'), icon: IvyIcons.Plus, action: () => action() };
   return (
     <>
-      <PathCollapsible
-        label={t('part.call.processStart')}
-        controls={[createProcess]}
-        defaultOpen={config.processCall !== defaultConfig.processCall}
-        path='processCall'
-      >
+      <PathCollapsible label={t('part.call.processStart')} controls={[createProcess]} defaultOpen={true} path='processCall'>
         <ValidationFieldset>
           <CallSelect
             start={config.processCall}

--- a/packages/inscription-view/src/components/parts/case/CasePart.test.tsx
+++ b/packages/inscription-view/src/components/parts/case/CasePart.test.tsx
@@ -22,7 +22,7 @@ describe('CasePart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Details');
+    await CollapsableUtil.assertOpen('Name / Description');
     await CollapsableUtil.assertClosed('Custom Fields');
   });
 

--- a/packages/inscription-view/src/components/parts/common/info/Information.tsx
+++ b/packages/inscription-view/src/components/parts/common/info/Information.tsx
@@ -39,7 +39,7 @@ const toWorkflowType = (path: '' | SchemaPath | SchemaKeys): WorkflowType => {
   return '' as WorkflowType;
 };
 
-const Information = <T extends InformationConfig>({ config, defaultConfig, update }: InformationProps<T>) => {
+const Information = <T extends InformationConfig>({ config, update }: InformationProps<T>) => {
   const { t } = useTranslation();
   const { context } = useEditorContext();
   const path = usePath();
@@ -53,13 +53,7 @@ const Information = <T extends InformationConfig>({ config, defaultConfig, updat
   ];
 
   return (
-    <ValidationCollapsible
-      label={t('common.label.details')}
-      defaultOpen={
-        config.name !== defaultConfig.name || config.description !== defaultConfig.description || config.category !== defaultConfig.category
-      }
-      paths={['name', 'description', 'category']}
-    >
+    <ValidationCollapsible label={t('part.general.nameAndDescription')} defaultOpen={true} paths={['name', 'description', 'category']}>
       <PathFieldset label={t('common.label.name')} path='name'>
         <MacroInput value={config.name} browsers={['attr', 'func', 'cms']} onChange={change => update('name', change)} />
       </PathFieldset>

--- a/packages/inscription-view/src/components/parts/common/mapping-tree/MappingPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/common/mapping-tree/MappingPart.test.tsx
@@ -62,8 +62,10 @@ describe('MappingPart', () => {
       <MappingPart
         browsers={['attr', 'func', 'type']}
         data={data}
+        defaultData={initData ?? { 'param.procurementRequest': 'in' }}
         variableInfo={variableInfo}
         onChange={(change: Record<string, string>) => (data = change)}
+        defaultOpen={true}
       />
     );
     return {
@@ -164,7 +166,14 @@ describe('MappingPart', () => {
 
   test('tree support readonly mode', async () => {
     customRender(
-      <MappingPart browsers={['attr', 'func', 'type']} data={{ bla: 'unknown value' }} variableInfo={variableInfo} onChange={() => {}} />,
+      <MappingPart
+        browsers={['attr', 'func', 'type']}
+        data={{ bla: 'unknown value' }}
+        defaultData={{ bla: 'unknown value' }}
+        variableInfo={variableInfo}
+        defaultOpen={true}
+        onChange={() => {}}
+      />,
       {
         wrapperProps: { editor: { readonly: true } }
       }

--- a/packages/inscription-view/src/components/parts/common/mapping-tree/MappingPart.tsx
+++ b/packages/inscription-view/src/components/parts/common/mapping-tree/MappingPart.tsx
@@ -7,16 +7,18 @@ import type { BrowserType } from '../../../browser/useBrowser';
 import { PathContext } from '../../../../context/usePath';
 import Fieldset from '../../../widgets/fieldset/Fieldset';
 import { useTranslation } from 'react-i18next';
+import { deepEqual } from '@axonivy/ui-components';
 
 export type MappingPartProps = {
   data: Record<string, string>;
   variableInfo: VariableInfo;
   onChange: (change: Record<string, string>) => void;
-  path?: SchemaKeys;
   browsers: BrowserType[];
+  path?: SchemaKeys;
+  defaultOpen?: boolean;
 };
 
-const MappingPart = ({ path, data, ...props }: MappingPartProps) => {
+const MappingPart = ({ path, data, defaultData, defaultOpen, ...props }: MappingPartProps & { defaultData: Record<string, string> }) => {
   const { t } = useTranslation();
   const globalFilter = useTableGlobalFilter();
   const onlyInscribedFilter = useTableOnlyInscribed();
@@ -25,7 +27,7 @@ const MappingPart = ({ path, data, ...props }: MappingPartProps) => {
       label={t('common.label.mapping')}
       controls={[globalFilter.control, onlyInscribedFilter.control]}
       path={path ?? 'map'}
-      defaultOpen={Object.keys(data).length > 0}
+      defaultOpen={defaultOpen ?? !deepEqual(data, defaultData)}
     >
       <MappingTree data={data} {...props} globalFilter={globalFilter} onlyInscribedFilter={onlyInscribedFilter} />
     </PathCollapsible>

--- a/packages/inscription-view/src/components/parts/common/permission/Permission.tsx
+++ b/packages/inscription-view/src/components/parts/common/permission/Permission.tsx
@@ -14,12 +14,13 @@ interface PermissionProps {
   config: StartPermission;
   defaultConfig: StartPermission;
   updatePermission: DataUpdater<StartPermission>;
+  defaultOpen?: boolean;
 }
 
-export const Permission = ({ anonymousFieldActive, config, defaultConfig, updatePermission }: PermissionProps) => {
+export const Permission = ({ anonymousFieldActive, config, defaultConfig, updatePermission, defaultOpen }: PermissionProps) => {
   const { t } = useTranslation();
   return (
-    <PathCollapsible path='permission' label={t('label.permission')} defaultOpen={!deepEqual(config, defaultConfig)}>
+    <PathCollapsible path='permission' label={t('label.permission')} defaultOpen={defaultOpen ?? !deepEqual(config, defaultConfig)}>
       {anonymousFieldActive && (
         <Checkbox label={t('label.allowAnonymous')} value={config.anonymous} onChange={change => updatePermission('anonymous', change)} />
       )}

--- a/packages/inscription-view/src/components/parts/common/responsible/ResponsiblePart.tsx
+++ b/packages/inscription-view/src/components/parts/common/responsible/ResponsiblePart.tsx
@@ -6,7 +6,7 @@ import ResponsibleSelect, { type ResponsibleSelectProps } from './ResponsibleSel
 import { PathFieldset } from '../path/PathFieldset';
 import { useTranslation } from 'react-i18next';
 
-type ResponsibleCollapsibleProps = ResponsibleSelectProps & { defaultResponsible: WfResponsible };
+type ResponsibleCollapsibleProps = ResponsibleSelectProps & { defaultResponsible: WfResponsible; defaultOpen?: boolean };
 
 export const ResponsibleCollapsible = (props: ResponsibleCollapsibleProps) => {
   const { t } = useTranslation();
@@ -14,7 +14,7 @@ export const ResponsibleCollapsible = (props: ResponsibleCollapsibleProps) => {
     <PathCollapsible
       label={t('label.responsible')}
       path='responsible'
-      defaultOpen={!deepEqual(props.responsible, props.defaultResponsible)}
+      defaultOpen={props.defaultOpen ?? !deepEqual(props.responsible, props.defaultResponsible)}
     >
       <ValidationFieldset>
         <ResponsibleSelect {...props} />

--- a/packages/inscription-view/src/components/parts/condition/ConditionPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/condition/ConditionPart.test.tsx
@@ -24,7 +24,7 @@ describe('ConditionPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Condition');
+    await CollapsableUtil.assertOpen('Condition');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/condition/ConditionTable.tsx
+++ b/packages/inscription-view/src/components/parts/condition/ConditionTable.tsx
@@ -99,7 +99,7 @@ const ConditionTable = ({ data, onChange }: { data: Condition[]; onChange: (chan
     : [];
 
   return (
-    <ValidationCollapsible label={t('part.condition.title')} controls={tableActions} defaultOpen={data.length > 0}>
+    <ValidationCollapsible label={t('part.condition.title')} controls={tableActions} defaultOpen={true}>
       <Table>
         <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={() => setRowSelection({})} />
         <TableBody>

--- a/packages/inscription-view/src/components/parts/end-page/EndPagePart.test.tsx
+++ b/packages/inscription-view/src/components/parts/end-page/EndPagePart.test.tsx
@@ -20,7 +20,7 @@ describe('EndPagePart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('End Page');
+    await CollapsableUtil.assertOpen('End Page');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/end-page/EndPagePart.tsx
+++ b/packages/inscription-view/src/components/parts/end-page/EndPagePart.tsx
@@ -27,11 +27,11 @@ export function useEndPagePart(): PartProps {
 
 const EndPagePart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update } = useEndPageData();
+  const { config, update } = useEndPageData();
   const action = useAction('openEndPage');
   const openFile: FieldsetControl = { label: t('label.openFile'), icon: IvyIcons.GoToSource, action: () => action(config.page) };
   return (
-    <PathCollapsible label={t('part.endPage.title')} controls={[openFile]} path='page' defaultOpen={config.page !== defaultConfig.page}>
+    <PathCollapsible label={t('part.endPage.title')} controls={[openFile]} path='page' defaultOpen={true}>
       <ValidationFieldset>
         <InputWithBrowser browsers={['cms']} typeFilter={'FILE'} value={config.page} onChange={change => update('page', change)} />
       </ValidationFieldset>

--- a/packages/inscription-view/src/components/parts/error/ErrorCatchPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/error/ErrorCatchPart.test.tsx
@@ -23,7 +23,7 @@ describe('ErrorCatchPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Error Code');
+    await CollapsableUtil.assertOpen('Error Code');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/error/ErrorCatchPart.tsx
+++ b/packages/inscription-view/src/components/parts/error/ErrorCatchPart.tsx
@@ -29,7 +29,7 @@ export function useErrorCatchPart(): PartProps {
 
 const ErrorCatchPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, updateError } = useErrorCatchData();
+  const { config, updateError } = useErrorCatchData();
   const { context } = useEditorContext();
   const errorCodes = [
     { value: '', label: t('part.error.empty'), info: t('part.error.emptyDesc') },
@@ -39,7 +39,7 @@ const ErrorCatchPart = () => {
   ];
 
   return (
-    <PathCollapsible label={t('part.error.code')} path='errorCode' defaultOpen={config.errorCode !== defaultConfig.errorCode}>
+    <PathCollapsible label={t('part.error.code')} path='errorCode' defaultOpen={true}>
       <ValidationFieldset>
         <ClassificationCombobox value={config.errorCode} onChange={change => updateError(change)} data={errorCodes} icon={IvyIcons.Error} />
       </ValidationFieldset>

--- a/packages/inscription-view/src/components/parts/error/ErrorThrowPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/error/ErrorThrowPart.test.tsx
@@ -24,7 +24,7 @@ describe('ErrorThrowPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Error');
+    await CollapsableUtil.assertOpen('Error');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/error/ErrorThrowPart.tsx
+++ b/packages/inscription-view/src/components/parts/error/ErrorThrowPart.tsx
@@ -4,7 +4,6 @@ import type { ErrorThrowData } from '@axonivy/process-editor-inscription-protoco
 import { IVY_SCRIPT_TYPES } from '@axonivy/process-editor-inscription-protocol';
 import { useErrorThrowData } from './useErrorThrowData';
 import { classifiedItemInfo } from '../../../utils/event-code-categorie';
-import { deepEqual } from '../../../utils/equals';
 import useMaximizedCodeEditor from '../../browser/useMaximizedCodeEditor';
 import { useValidations } from '../../../context/useValidation';
 import { useEditorContext } from '../../../context/useEditorContext';
@@ -46,7 +45,7 @@ const ErrorThrowPart = () => {
 
   return (
     <>
-      <PathCollapsible label={t('part.error.title')} path='throws' defaultOpen={!deepEqual(config.throws, defaultConfig.throws)}>
+      <PathCollapsible label={t('part.error.title')} path='throws' defaultOpen={true}>
         <PathFieldset label={t('part.error.codeToThrow')} path='error'>
           <ClassificationCombobox
             value={config.throws.error}

--- a/packages/inscription-view/src/components/parts/mail/MailAttachmentPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/mail/MailAttachmentPart.test.tsx
@@ -17,7 +17,7 @@ describe('MailAttachmentPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Attachments');
+    await CollapsableUtil.assertOpen('Attachments');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/mail/MailAttachmentPart.tsx
+++ b/packages/inscription-view/src/components/parts/mail/MailAttachmentPart.tsx
@@ -73,7 +73,7 @@ const MailAttachmentTable = () => {
   const tableActions = table.getSelectedRowModel().rows.length > 0 ? [removeRowAction] : [];
 
   return (
-    <ValidationCollapsible label={t('part.mail.attachments.title')} controls={tableActions} defaultOpen={config.attachments.length > 0}>
+    <ValidationCollapsible label={t('part.mail.attachments.title')} controls={tableActions} defaultOpen={true}>
       <div>
         {table.getRowModel().rows.length > 0 && (
           <Table>

--- a/packages/inscription-view/src/components/parts/mail/MailErrorPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/mail/MailErrorPart.test.tsx
@@ -17,7 +17,7 @@ describe('MailErrorPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Error');
+    await CollapsableUtil.assertOpen('Error');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/mail/MailErrorPart.tsx
+++ b/packages/inscription-view/src/components/parts/mail/MailErrorPart.tsx
@@ -27,13 +27,10 @@ export function useMailErrorPart(): PartProps {
 
 const MailErrorPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update } = useMailData();
+  const { config, update } = useMailData();
 
   return (
-    <ValidationCollapsible
-      label={t('part.error.title')}
-      defaultOpen={config.failIfMissingAttachments || config.exceptionHandler !== defaultConfig.exceptionHandler}
-    >
+    <ValidationCollapsible label={t('part.error.title')} defaultOpen={true}>
       <PathContext path='exceptionHandler'>
         <ExceptionSelect
           value={config.exceptionHandler}

--- a/packages/inscription-view/src/components/parts/mail/MailHeaderPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/mail/MailHeaderPart.test.tsx
@@ -26,7 +26,7 @@ describe('MailHeaderPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Header');
+    await CollapsableUtil.assertOpen('Header');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/mail/MailHeaderPart.tsx
+++ b/packages/inscription-view/src/components/parts/mail/MailHeaderPart.tsx
@@ -1,7 +1,6 @@
 import { usePartState, type PartProps } from '../../editors/part/usePart';
 import { useMailData } from './useMailData';
 import type { MailData } from '@axonivy/process-editor-inscription-protocol';
-import { deepEqual } from '../../../utils/equals';
 import { useValidations } from '../../../context/useValidation';
 import type { BrowserType } from '../../browser/useBrowser';
 import { PathCollapsible } from '../common/path/PathCollapsible';
@@ -27,12 +26,12 @@ export function useMailHeaderPart(): PartProps {
 
 const MailHeaderPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, updateHeader } = useMailData();
+  const { config, updateHeader } = useMailData();
   const borwserTypes: BrowserType[] = ['attr', 'func', 'cms'];
 
   return (
     <>
-      <PathCollapsible label={t('part.mail.header.title')} path='headers' defaultOpen={!deepEqual(config.headers, defaultConfig.headers)}>
+      <PathCollapsible label={t('part.mail.header.title')} path='headers' defaultOpen={true}>
         <PathFieldset label={t('part.mail.header.subject')} path='subject'>
           <MacroInput value={config.headers.subject} onChange={change => updateHeader('subject', change)} browsers={borwserTypes} />
         </PathFieldset>

--- a/packages/inscription-view/src/components/parts/mail/MailMessagePart.test.tsx
+++ b/packages/inscription-view/src/components/parts/mail/MailMessagePart.test.tsx
@@ -23,7 +23,7 @@ describe('MailMessagePart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Content');
+    await CollapsableUtil.assertOpen('Content');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/mail/MailMessagePart.tsx
+++ b/packages/inscription-view/src/components/parts/mail/MailMessagePart.tsx
@@ -30,11 +30,11 @@ export function useMailMessagePart(): PartProps {
 
 const MailMessagePart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, updateMessage } = useMailData();
+  const { config, updateMessage } = useMailData();
   const typeItems = useMemo<SelectItem[]>(() => Object.values(MAIL_TYPE).map(value => ({ label: value, value })), []);
 
   return (
-    <ValidationCollapsible label={t('part.mail.content.title')} defaultOpen={config.message.body !== defaultConfig.message.body}>
+    <ValidationCollapsible label={t('part.mail.content.title')} defaultOpen={true}>
       <PathFieldset label={t('part.mail.content.message')} path='message'>
         <MacroArea value={config.message.body} onChange={change => updateMessage('body', change)} browsers={['attr', 'func', 'cms']} />
       </PathFieldset>

--- a/packages/inscription-view/src/components/parts/name/GeneralPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/name/GeneralPart.test.tsx
@@ -21,7 +21,7 @@ describe('NamePart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Name / Description');
+    await CollapsableUtil.assertOpen('Name / Description');
     await CollapsableUtil.assertClosed('Means / Documents');
     await CollapsableUtil.assertClosed('Tags');
   });

--- a/packages/inscription-view/src/components/parts/name/GeneralPart.tsx
+++ b/packages/inscription-view/src/components/parts/name/GeneralPart.tsx
@@ -33,7 +33,7 @@ const GeneralPart = ({ hideTags, disableName }: { hideTags?: boolean; disableNam
 
   return (
     <>
-      <Collapsible label={t('part.general.nameAndDescription')} defaultOpen={data.name !== '' || data.description !== ''}>
+      <Collapsible label={t('part.general.nameAndDescription')} defaultOpen={true}>
         <Fieldset label={t('part.general.displayName')}>
           <Textarea maxRows={3} disabled={!!disableName} value={data.name} onChange={change => update('name', change)} />
         </Fieldset>

--- a/packages/inscription-view/src/components/parts/output/OutputPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/output/OutputPart.test.tsx
@@ -21,7 +21,7 @@ describe('OutputPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Mapping');
+    await CollapsableUtil.assertOpen('Mapping');
     await CollapsableUtil.assertClosed('Code');
   });
 

--- a/packages/inscription-view/src/components/parts/permissions/PermissionsPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/permissions/PermissionsPart.test.tsx
@@ -19,7 +19,7 @@ describe('PermissionsPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Permissions');
+    await CollapsableUtil.assertOpen('Permissions');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/permissions/PermissionsPart.tsx
+++ b/packages/inscription-view/src/components/parts/permissions/PermissionsPart.tsx
@@ -22,12 +22,9 @@ export function usePermissionsPart(): PartProps {
 
 const PermissionsPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update } = usePermissionsData();
+  const { config, update } = usePermissionsData();
   return (
-    <Collapsible
-      label={t('part.permission.title')}
-      defaultOpen={config.permissions.view.allowed !== defaultConfig.permissions.view.allowed}
-    >
+    <Collapsible label={t('part.permission.title')} defaultOpen={true}>
       <Checkbox
         label={t('part.permission.allowProcessViewer')}
         value={config.permissions.view.allowed}

--- a/packages/inscription-view/src/components/parts/process-data/ProcessDataPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/process-data/ProcessDataPart.test.tsx
@@ -19,7 +19,7 @@ describe('ProcessDataPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Data Class');
+    await CollapsableUtil.assertOpen('Data Class');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/process-data/ProcessDataPart.tsx
+++ b/packages/inscription-view/src/components/parts/process-data/ProcessDataPart.tsx
@@ -29,7 +29,7 @@ export function useProcessDataPart(): PartProps {
 
 const ProcessDataPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update } = useProcessDataData();
+  const { config, update } = useProcessDataData();
   const { context } = useEditorContext();
   const dataClasses = [
     ...useMeta('meta/scripting/dataClasses', context, []).data.map<DataClassItem>(dataClass => {
@@ -38,7 +38,7 @@ const ProcessDataPart = () => {
   ];
 
   return (
-    <PathCollapsible label={t('part.processData.dataClass')} path='data' defaultOpen={config.data !== defaultConfig.data}>
+    <PathCollapsible label={t('part.processData.dataClass')} path='data' defaultOpen={true}>
       <ValidationFieldset>
         <DataClassSelector dataClass={config.data} onChange={change => update('data', change)} dataClasses={dataClasses} />
       </ValidationFieldset>

--- a/packages/inscription-view/src/components/parts/program/JavaClassSelector.test.tsx
+++ b/packages/inscription-view/src/components/parts/program/JavaClassSelector.test.tsx
@@ -20,7 +20,7 @@ describe('StartPart', () => {
 
   test('empty', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Java Class');
+    await CollapsableUtil.assertOpen('Java Class');
   });
 
   test('meta', async () => {

--- a/packages/inscription-view/src/components/parts/program/JavaClassSelector.tsx
+++ b/packages/inscription-view/src/components/parts/program/JavaClassSelector.tsx
@@ -38,7 +38,7 @@ const JavaClassSelector = ({ javaClass, onChange, type }: JavaClassSelectorProps
       label={t('part.program.javaClass')}
       path='javaClass'
       controls={[openJavaClassConfig, createJavaClass]}
-      defaultOpen={javaClass !== ''}
+      defaultOpen={true}
     >
       <ValidationFieldset>
         <Combobox value={javaClass} onChange={item => onChange(item)} items={javaClassItems} />

--- a/packages/inscription-view/src/components/parts/program/activity/ProgramInterfaceErrorPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/program/activity/ProgramInterfaceErrorPart.test.tsx
@@ -19,7 +19,7 @@ describe('ProgramInterfaceErrorPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Error');
+    await CollapsableUtil.assertOpen('Error');
     await CollapsableUtil.assertClosed('Timeout');
   });
 

--- a/packages/inscription-view/src/components/parts/program/activity/ProgramInterfaceErrorPart.tsx
+++ b/packages/inscription-view/src/components/parts/program/activity/ProgramInterfaceErrorPart.tsx
@@ -33,11 +33,7 @@ const ProgramInterfaceErrorPart = () => {
 
   return (
     <>
-      <PathCollapsible
-        label={t('part.program.error.title')}
-        path='exceptionHandler'
-        defaultOpen={config.exceptionHandler !== defaultConfig.exceptionHandler}
-      >
+      <PathCollapsible label={t('part.program.error.title')} path='exceptionHandler' defaultOpen={true}>
         <PathContext path='error'>
           <ExceptionSelect
             value={config.exceptionHandler}

--- a/packages/inscription-view/src/components/parts/program/activity/ProgramInterfaceStartPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/program/activity/ProgramInterfaceStartPart.test.tsx
@@ -19,7 +19,7 @@ describe('ProgramInterfaceStartPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Java Class');
+    await CollapsableUtil.assertOpen('Java Class');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/program/event/ProgramStartPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/program/event/ProgramStartPart.test.tsx
@@ -20,7 +20,7 @@ describe('StartPart', () => {
   test('empty data', async () => {
     renderPart();
     await CollapsableUtil.assertClosed('Permission');
-    await CollapsableUtil.assertClosed('Java Class');
+    await CollapsableUtil.assertOpen('Java Class');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/program/intermediate/EventPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/program/intermediate/EventPart.test.tsx
@@ -19,8 +19,8 @@ describe('EventPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Java Class');
-    await CollapsableUtil.assertClosed('Event ID');
+    await CollapsableUtil.assertOpen('Java Class');
+    await CollapsableUtil.assertOpen('Event ID');
     await CollapsableUtil.assertClosed('Expiry');
   });
 

--- a/packages/inscription-view/src/components/parts/program/intermediate/EventPart.tsx
+++ b/packages/inscription-view/src/components/parts/program/intermediate/EventPart.tsx
@@ -52,7 +52,7 @@ const EventPart = ({ thirdParty }: { thirdParty?: boolean }) => {
         <JavaClassSelector javaClass={config.javaClass} onChange={change => update('javaClass', change)} type='INTERMEDIATE' />
       )}
 
-      <PathCollapsible label={t('part.program.event.id')} path='eventId' defaultOpen={config.eventId !== defaultConfig.eventId}>
+      <PathCollapsible label={t('part.program.event.id')} path='eventId' defaultOpen={true}>
         <ValidationFieldset>
           <ScriptInput
             value={config.eventId}

--- a/packages/inscription-view/src/components/parts/query/QueryPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/query/QueryPart.test.tsx
@@ -83,7 +83,7 @@ describe('QueryPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Database');
+    await CollapsableUtil.assertOpen('Database');
     await CollapsableUtil.assertClosed('Fields');
     await CollapsableUtil.assertClosed('Condition');
     await CollapsableUtil.assertClosed('Sort');

--- a/packages/inscription-view/src/components/parts/query/QueryPart.tsx
+++ b/packages/inscription-view/src/components/parts/query/QueryPart.tsx
@@ -37,7 +37,7 @@ const QueryPart = () => {
   return (
     <>
       <PathContext path='query'>
-        <ValidationCollapsible label={t('label.database')} defaultOpen={config.query.dbName.length > 0}>
+        <ValidationCollapsible label={t('label.database')} defaultOpen={true}>
           <QueryKindSelect />
           <DatabaseSelect />
           {config.query.sql.kind !== 'ANY' && <TableSelect />}

--- a/packages/inscription-view/src/components/parts/query/db-error/DbErrorPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/query/db-error/DbErrorPart.test.tsx
@@ -19,7 +19,7 @@ describe('DbErrorPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Error');
+    await CollapsableUtil.assertOpen('Error');
   });
 
   function assertState(expectedState: PartStateFlag, data?: DeepPartial<DbErrorData>, validation?: ValidationResult) {

--- a/packages/inscription-view/src/components/parts/query/db-error/DbErrorPart.tsx
+++ b/packages/inscription-view/src/components/parts/query/db-error/DbErrorPart.tsx
@@ -25,13 +25,9 @@ export function useDbErrorPart(): PartProps {
 
 const QueryPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, updateException } = useDbErrorData();
+  const { config, updateException } = useDbErrorData();
   return (
-    <PathCollapsible
-      label={t('label.error')}
-      defaultOpen={config.exceptionHandler !== defaultConfig.exceptionHandler}
-      path='exceptionHandler'
-    >
+    <PathCollapsible label={t('label.error')} defaultOpen={true} path='exceptionHandler'>
       <ValidationFieldset>
         <ExceptionSelect
           value={config.exceptionHandler}

--- a/packages/inscription-view/src/components/parts/request/RequestPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/request/RequestPart.test.tsx
@@ -56,7 +56,7 @@ describe('RequestPart', () => {
     const httpCheckbox = screen.getByLabelText('Yes, this can be started with a HTTP-Request / -Link');
     expect(httpCheckbox).toBeChecked();
     expect(screen.getByLabelText('Show on start list')).not.toBeChecked();
-    expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
+    await CollapsableUtil.assertOpen('Name / Description');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/rest/RestErrorPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/rest/RestErrorPart.test.tsx
@@ -17,7 +17,7 @@ describe('RestErrorPart', () => {
 
   test('empty', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Error');
+    await CollapsableUtil.assertOpen('Error');
   });
 
   test('data', async () => {

--- a/packages/inscription-view/src/components/parts/rest/RestErrorPart.tsx
+++ b/packages/inscription-view/src/components/parts/rest/RestErrorPart.tsx
@@ -26,17 +26,10 @@ export function useRestErrorPart(): PartProps {
 
 const RestErrorPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update } = useRestErrorData();
+  const { config, update } = useRestErrorData();
   return (
     <PathContext path='response'>
-      <ValidationCollapsible
-        label={t('label.error')}
-        defaultOpen={
-          config.response.clientError !== defaultConfig.response.clientError ||
-          config.response.statusError !== defaultConfig.response.statusError
-        }
-        paths={['clientError', 'statusError']}
-      >
+      <ValidationCollapsible label={t('label.error')} defaultOpen={true} paths={['clientError', 'statusError']}>
         <RestError
           label={t('part.rest.onError')}
           value={config.response.clientError}

--- a/packages/inscription-view/src/components/parts/rest/RestOutputPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/rest/RestOutputPart.test.tsx
@@ -17,8 +17,8 @@ describe('RestOutputPart', () => {
 
   test('empty', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Result Type');
-    await CollapsableUtil.assertClosed('Mapping');
+    await CollapsableUtil.assertOpen('Result Type');
+    await CollapsableUtil.assertOpen('Mapping');
     await CollapsableUtil.assertClosed('Code');
   });
 

--- a/packages/inscription-view/src/components/parts/rest/RestOutputPart.tsx
+++ b/packages/inscription-view/src/components/parts/rest/RestOutputPart.tsx
@@ -48,11 +48,7 @@ const RestOutputPart = () => {
     <PathContext path='response'>
       <PathContext path='entity'>
         {showResultType && (
-          <PathCollapsible
-            label={t('part.rest.resultType')}
-            path='type'
-            defaultOpen={config.response.entity.type !== defaultConfig.response.entity.type}
-          >
+          <PathCollapsible label={t('part.rest.resultType')} path='type' defaultOpen={true}>
             <ValidationFieldset label={t('part.rest.readBodyType')}>
               <RestEntityTypeCombobox
                 value={config.response.entity.type}
@@ -67,6 +63,8 @@ const RestOutputPart = () => {
           variableInfo={variableInfo}
           browsers={['attr', 'func', 'type']}
           onChange={change => updateEntity('map', change)}
+          defaultData={defaultConfig.response.entity.map}
+          defaultOpen={true}
         />
         <PathCollapsible
           label={t('label.code')}

--- a/packages/inscription-view/src/components/parts/rest/RestRequestPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/rest/RestRequestPart.test.tsx
@@ -22,7 +22,7 @@ describe('RestRequestPart', () => {
 
   test('empty', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Rest Service');
+    await CollapsableUtil.assertOpen('Rest Service');
     await CollapsableUtil.assertClosed('Parameters');
     await CollapsableUtil.assertClosed('Headers');
     await CollapsableUtil.assertClosed('Properties');

--- a/packages/inscription-view/src/components/parts/rest/RestRequestPart.tsx
+++ b/packages/inscription-view/src/components/parts/rest/RestRequestPart.tsx
@@ -42,7 +42,7 @@ export function useRestRequestPart(): PartProps {
 
 const RestRequestPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig } = useRestRequestData();
+  const { config } = useRestRequestData();
 
   const bodyPart = (method: HttpMethod) => {
     switch (method) {
@@ -60,7 +60,7 @@ const RestRequestPart = () => {
   return (
     <>
       <PathContext path='target'>
-        <ValidationCollapsible label={t('part.rest.service')} defaultOpen={config.target.clientId !== defaultConfig.target.clientId}>
+        <ValidationCollapsible label={t('part.rest.service')} defaultOpen={true}>
           <RestTargetUrl />
           <RestClientSelect />
           <RestMethodSelect />
@@ -81,7 +81,7 @@ const OpenApiSwitch = () => {
   const { config } = useRestRequestData();
   const resources = useMeta('meta/rest/resources', { context, clientId: config.target.clientId }, []).data;
   if (resources.length === 0) {
-    return null;
+    return;
   }
   return (
     <Field direction='row' alignItems='center' gap={2}>

--- a/packages/inscription-view/src/components/parts/result/ResultPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/result/ResultPart.test.tsx
@@ -30,7 +30,7 @@ describe('ResultPart', () => {
   test('empty data', async () => {
     renderPart();
     await CollapsableUtil.assertClosed('Result parameters');
-    await CollapsableUtil.assertClosed('Mapping');
+    await CollapsableUtil.assertOpen('Mapping');
     await CollapsableUtil.assertClosed('Code');
   });
 

--- a/packages/inscription-view/src/components/parts/result/ResultPart.tsx
+++ b/packages/inscription-view/src/components/parts/result/ResultPart.tsx
@@ -55,8 +55,10 @@ const ResultPart = ({ hideParamDesc }: { hideParamDesc?: boolean }) => {
       <MappingPart
         data={config.result.map}
         variableInfo={variableInfo}
+        defaultData={defaultConfig.result.map}
         onChange={change => update('map', change)}
         browsers={['attr', 'func', 'type']}
+        defaultOpen={true}
       />
       <PathCollapsible
         label={t('label.code')}

--- a/packages/inscription-view/src/components/parts/signal/SignalCatchPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/signal/SignalCatchPart.test.tsx
@@ -16,7 +16,7 @@ describe('SignalCatchPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Signal Code');
+    await CollapsableUtil.assertOpen('Signal Code');
   });
 
   test('boundary', async () => {

--- a/packages/inscription-view/src/components/parts/signal/SignalCatchPart.tsx
+++ b/packages/inscription-view/src/components/parts/signal/SignalCatchPart.tsx
@@ -30,7 +30,7 @@ export function useSignalCatchPart(options?: { makroSupport?: boolean; withBrows
 
 const SignalCatchPart = ({ makroSupport, withBrowser }: { makroSupport?: boolean; withBrowser?: boolean }) => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update, updateSignal } = useSignalCatchData();
+  const { config, update, updateSignal } = useSignalCatchData();
   const { context } = useEditorContext();
   const signalCodes = [
     { value: '', label: t('part.signal.empty'), info: t('part.signal.emptyDesc') },
@@ -40,7 +40,7 @@ const SignalCatchPart = ({ makroSupport, withBrowser }: { makroSupport?: boolean
   ];
 
   return (
-    <PathCollapsible label={t('part.signal.code')} path='signalCode' defaultOpen={config.signalCode !== defaultConfig.signalCode}>
+    <PathCollapsible label={t('part.signal.code')} path='signalCode' defaultOpen={true}>
       <ValidationFieldset>
         <ClassificationCombobox
           value={config.signalCode}

--- a/packages/inscription-view/src/components/parts/start/StartPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/start/StartPart.test.tsx
@@ -32,7 +32,7 @@ describe('StartPart', () => {
     renderPart();
     await CollapsableUtil.assertClosed('Signature');
     await CollapsableUtil.assertClosed('Input parameters');
-    await CollapsableUtil.assertClosed('Mapping');
+    await CollapsableUtil.assertOpen('Mapping');
     await CollapsableUtil.assertClosed('Code');
   });
 

--- a/packages/inscription-view/src/components/parts/start/StartPart.tsx
+++ b/packages/inscription-view/src/components/parts/start/StartPart.tsx
@@ -15,7 +15,7 @@ import { ScriptArea } from '../../widgets/code-editor/ScriptArea';
 import { useTranslation } from 'react-i18next';
 import { IvyIcons } from '@axonivy/ui-icons';
 
-type StartPartProps = { hideParamDesc?: boolean; synchParams?: boolean };
+type StartPartProps = { hideParamDesc?: boolean; synchParams?: boolean; signatureDefaultOpen?: boolean };
 
 export const useStartPartValidation = () => {
   const signarture = useValidations(['signature']);
@@ -38,7 +38,7 @@ export function useStartPart(props?: StartPartProps): PartProps {
   };
 }
 
-const StartPart = ({ hideParamDesc, synchParams }: StartPartProps) => {
+const StartPart = ({ hideParamDesc, synchParams, signatureDefaultOpen }: StartPartProps) => {
   const { t } = useTranslation();
   const { config, defaultConfig, updateSignature, update } = useStartData(synchParams);
   const { elementContext: context } = useEditorContext();
@@ -46,7 +46,11 @@ const StartPart = ({ hideParamDesc, synchParams }: StartPartProps) => {
   const { maximizeState, maximizeCode } = useMaximizedCodeEditor();
   return (
     <>
-      <PathCollapsible label={t('part.start.signature')} path='signature' defaultOpen={config.signature !== defaultConfig.signature}>
+      <PathCollapsible
+        label={t('part.start.signature')}
+        path='signature'
+        defaultOpen={signatureDefaultOpen ?? config.signature !== defaultConfig.signature}
+      >
         <ValidationFieldset>
           <Input value={config.signature} onChange={change => updateSignature(change)} />
         </ValidationFieldset>
@@ -60,9 +64,11 @@ const StartPart = ({ hideParamDesc, synchParams }: StartPartProps) => {
         />
         <MappingPart
           data={config.input.map}
+          defaultData={defaultConfig.input.map}
           variableInfo={variableInfo}
           onChange={change => update('map', change)}
           browsers={['attr', 'func', 'type']}
+          defaultOpen={true}
         />
         <PathCollapsible
           label={t('label.code')}

--- a/packages/inscription-view/src/components/parts/task/task/Task.test.tsx
+++ b/packages/inscription-view/src/components/parts/task/task/Task.test.tsx
@@ -25,7 +25,7 @@ describe('Task', () => {
 
   test('task part render empty', async () => {
     renderTask();
-    await CollapsableUtil.assertClosed('Details');
+    await CollapsableUtil.assertOpen('Name / Description');
     await CollapsableUtil.assertClosed('Responsible');
     await CollapsableUtil.assertClosed('Priority');
     await CollapsableUtil.assertClosed('Options');

--- a/packages/inscription-view/src/components/parts/trigger/TriggerPart.tsx
+++ b/packages/inscription-view/src/components/parts/trigger/TriggerPart.tsx
@@ -47,6 +47,7 @@ const TriggerPart = () => {
                 responsible={config.task.responsible}
                 defaultResponsible={defaultConfig.task.responsible}
                 updateResponsible={updateResponsible}
+                defaultOpen={true}
               />
               <ValidationCollapsible
                 label={t('part.task.options')}

--- a/packages/inscription-view/src/components/parts/web-service-process/WebServiceProcessPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/web-service-process/WebServiceProcessPart.test.tsx
@@ -19,7 +19,7 @@ describe('WebServiceProcessPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Process');
+    await CollapsableUtil.assertOpen('Process');
   });
 
   test('full data', async () => {

--- a/packages/inscription-view/src/components/parts/web-service-process/WebServiceProcessPart.tsx
+++ b/packages/inscription-view/src/components/parts/web-service-process/WebServiceProcessPart.tsx
@@ -40,10 +40,10 @@ const useAuthTypes = () => {
 
 const WebServiceProcessPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update } = useWebServiceProcessData();
+  const { config, update } = useWebServiceProcessData();
   const items = useAuthTypes();
   return (
-    <ValidationCollapsible label={t('label.process')} defaultOpen={config.wsTypeName !== defaultConfig.wsTypeName}>
+    <ValidationCollapsible label={t('label.process')} defaultOpen={true}>
       <PathFieldset label={t('part.wsprocess.qualifiedName')} path='wsTypeName'>
         <Input value={config.wsTypeName} onChange={change => update('wsTypeName', change)} type={IVY_SCRIPT_TYPES.STRING} />
       </PathFieldset>

--- a/packages/inscription-view/src/components/parts/web-service/WebServicePart.tsx
+++ b/packages/inscription-view/src/components/parts/web-service/WebServicePart.tsx
@@ -41,6 +41,7 @@ const WebServicePart = () => {
         config={config.permission}
         defaultConfig={defaultConfig.permission}
         updatePermission={updatePermission}
+        defaultOpen={true}
       />
       <Exception />
     </>

--- a/packages/inscription-view/src/components/parts/ws-error/WsErrorPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/ws-error/WsErrorPart.test.tsx
@@ -17,7 +17,7 @@ describe('WsResponsePart', () => {
 
   test('empty', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Error');
+    await CollapsableUtil.assertOpen('Error');
   });
 
   test('data', async () => {

--- a/packages/inscription-view/src/components/parts/ws-error/WsErrorPart.tsx
+++ b/packages/inscription-view/src/components/parts/ws-error/WsErrorPart.tsx
@@ -26,13 +26,9 @@ export function useWsErrorPart(): PartProps {
 
 const WsErrorPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig, update } = useWsErrorData();
+  const { config, update } = useWsErrorData();
   return (
-    <PathCollapsible
-      label={t('label.error')}
-      defaultOpen={config.exceptionHandler !== defaultConfig.exceptionHandler}
-      path='exceptionHandler'
-    >
+    <PathCollapsible label={t('label.error')} defaultOpen={true} path='exceptionHandler'>
       <ValidationFieldset>
         <ExceptionSelect
           value={config.exceptionHandler}

--- a/packages/inscription-view/src/components/parts/ws-request/WsMapping.tsx
+++ b/packages/inscription-view/src/components/parts/ws-request/WsMapping.tsx
@@ -5,7 +5,7 @@ import MappingPart from '../common/mapping-tree/MappingPart';
 import { useWsRequestData } from './useWsRequestData';
 
 export const WsMapping = () => {
-  const { config, updateOperation } = useWsRequestData();
+  const { config, defaultConfig, updateOperation } = useWsRequestData();
 
   const { context } = useEditorContext();
   const variableInfo = useMeta('meta/webservice/operations', { clientId: config.clientId, port: config.operation.port, context }, [])
@@ -17,6 +17,7 @@ export const WsMapping = () => {
     <PathContext path='operation'>
       <MappingPart
         data={config.operation.parameters}
+        defaultData={defaultConfig.operation.parameters}
         onChange={change => updateOperation('parameters', change)}
         variableInfo={variableInfo}
         path='parameters'

--- a/packages/inscription-view/src/components/parts/ws-request/WsRequestPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/ws-request/WsRequestPart.test.tsx
@@ -17,7 +17,7 @@ describe('WsRequestPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await CollapsableUtil.assertClosed('Web Service');
+    await CollapsableUtil.assertOpen('Web Service');
     await CollapsableUtil.assertClosed('Properties');
     await CollapsableUtil.assertClosed('Mapping');
   });

--- a/packages/inscription-view/src/components/parts/ws-request/WsRequestPart.tsx
+++ b/packages/inscription-view/src/components/parts/ws-request/WsRequestPart.tsx
@@ -28,10 +28,9 @@ export function useWsRequestPart(): PartProps {
 
 const WsRequestPart = () => {
   const { t } = useTranslation();
-  const { config, defaultConfig } = useWsRequestData();
   return (
     <>
-      <ValidationCollapsible label={t('part.ws.title')} defaultOpen={config.clientId !== defaultConfig.clientId}>
+      <ValidationCollapsible label={t('part.ws.title')} defaultOpen={true}>
         <WsClientSelect />
         <WsPortSelect />
         <WsOperationSelect />

--- a/packages/inscription-view/src/test-utils/collapsible-utils.tsx
+++ b/packages/inscription-view/src/test-utils/collapsible-utils.tsx
@@ -11,6 +11,8 @@ export namespace CollapsableUtil {
   }
 
   export async function assertOpen(byText: string) {
-    expect((await screen.findByText(byText)).parentNode).toHaveAttribute('data-state', 'open');
+    const el = screen.getAllByText(byText).find(el => el.closest('.ui-collapsible'));
+    if (!el) throw new Error(`No element with text '${byText}' inside a .ui-collapsible`);
+    expect(el.closest('.ui-collapsible')).toHaveAttribute('data-state', 'open');
   }
 }

--- a/playwright/tests/inscription/mock/keyboard-navigation.spec.ts
+++ b/playwright/tests/inscription/mock/keyboard-navigation.spec.ts
@@ -6,7 +6,7 @@ test.describe('Keyboard Navigation', () => {
     const inscriptionView = await openMockInscription(page);
     const taskPart = inscriptionView.inscriptionTab('Task');
     await taskPart.open();
-    const detailsSection = taskPart.section('Details');
+    const detailsSection = taskPart.section('Name / Description');
     await page.keyboard.press('Tab');
     await page.keyboard.press('Tab');
     await page.keyboard.press('Tab');

--- a/playwright/tests/inscription/mock/validation.spec.ts
+++ b/playwright/tests/inscription/mock/validation.spec.ts
@@ -9,7 +9,7 @@ test.describe('Validations', () => {
   test('case', async ({ page }) => {
     const inscriptionView = await openMockInscription(page);
     const part = inscriptionView.inscriptionTab('Case');
-    const section = part.section('Details');
+    const section = part.section('Name / Description');
     const name = section.macroInput('Name');
     const desc = section.macroArea('Description');
 

--- a/playwright/tests/inscription/parts/call.ts
+++ b/playwright/tests/inscription/parts/call.ts
@@ -13,7 +13,12 @@ class Call extends PartObject {
   codeSection: Section;
   code: ScriptArea;
 
-  constructor(part: Part, readonly selectLabel: string, private readonly selectValue: string, private readonly assertSelectValue: string) {
+  constructor(
+    part: Part,
+    readonly selectLabel: string,
+    private readonly selectValue: string,
+    private readonly assertSelectValue: string
+  ) {
     super(part);
     this.callSection = part.section(selectLabel);
     this.call = this.callSection.combobox();
@@ -24,9 +29,9 @@ class Call extends PartObject {
   }
 
   async fill() {
-    await this.callSection.open();
+    await this.callSection.expectIsOpen();
     await this.call.choose(this.selectValue);
-    await this.mappingSection.open();
+    await this.mappingSection.expectIsOpen();
     await this.mapping.row(2).column(1).fill('"test"');
     await this.codeSection.open();
     await this.code.fill('code');
@@ -45,7 +50,7 @@ class Call extends PartObject {
 
   async assertClear() {
     await this.call.expectValue(this.assertSelectValue);
-    await this.mappingSection.expectIsClosed();
+    await this.mappingSection.expectIsOpen();
     await this.codeSection.expectIsClosed();
   }
 }

--- a/playwright/tests/inscription/parts/db-error.ts
+++ b/playwright/tests/inscription/parts/db-error.ts
@@ -14,8 +14,7 @@ class DbErrorPart extends PartObject {
   }
 
   async fill(): Promise<void> {
-    await this.section.expectIsClosed();
-    await this.section.toggle();
+    await this.section.expectIsOpen();
     await this.error.choose('>> Ignore Exception');
   }
   async assertFill(): Promise<void> {
@@ -26,7 +25,7 @@ class DbErrorPart extends PartObject {
     await this.error.choose('ivy:error:database');
   }
   async assertClear(): Promise<void> {
-    await this.section.expectIsClosed();
+    await this.section.expectIsOpen();
   }
 }
 

--- a/playwright/tests/inscription/parts/end-page.ts
+++ b/playwright/tests/inscription/parts/end-page.ts
@@ -14,7 +14,7 @@ class EndPage extends PartObject {
   }
 
   async fill() {
-    await this.section.open();
+    await this.section.expectIsOpen();
     await this.endPage.fill('page.xhtml');
   }
 
@@ -27,7 +27,7 @@ class EndPage extends PartObject {
   }
 
   async assertClear() {
-    await this.section.open();
+    await this.section.expectIsOpen();
     await this.endPage.expectEmpty();
   }
 }

--- a/playwright/tests/inscription/parts/error-catch.ts
+++ b/playwright/tests/inscription/parts/error-catch.ts
@@ -14,7 +14,7 @@ class ErrorCatch extends PartObject {
   }
 
   async fill() {
-    await this.section.open();
+    await this.section.expectIsOpen();
     await this.error.choose('ivy:error');
   }
 
@@ -27,7 +27,7 @@ class ErrorCatch extends PartObject {
   }
 
   async assertClear() {
-    await this.section.expectIsClosed();
+    await this.section.expectIsOpen();
   }
 }
 

--- a/playwright/tests/inscription/parts/event.ts
+++ b/playwright/tests/inscription/parts/event.ts
@@ -33,9 +33,9 @@ class Event extends PartObject {
   }
 
   async fill() {
-    await this.javaSection.open();
+    await this.javaSection.expectIsOpen();
     await this.javaClass.choose('ch.ivyteam.ivy.process.intermediateevent.AbstractProcessIntermediateEventBean');
-    await this.eventSection.open();
+    await this.eventSection.expectIsOpen();
     await this.eventId.fill('123');
 
     await this.expirySection.toggle();
@@ -64,7 +64,7 @@ class Event extends PartObject {
 
   async assertClear() {
     await this.javaClass.expectValue('ch.ivyteam.ivy.process.intermediateevent.AbstractProcessIntermediateEventBean');
-    await this.eventSection.open();
+    await this.eventSection.expectIsOpen();
     await this.eventId.expectEmpty();
     await this.expirySection.expectIsClosed();
   }

--- a/playwright/tests/inscription/parts/mail-attachments.ts
+++ b/playwright/tests/inscription/parts/mail-attachments.ts
@@ -14,7 +14,7 @@ class Attachements extends PartObject {
   }
 
   async fill() {
-    await this.section.open();
+    await this.section.expectIsOpen();
     const row = await this.table.addRow();
     await row.fill(['hi']);
   }
@@ -25,7 +25,7 @@ class Attachements extends PartObject {
     await this.table.row(0).remove(true);
   }
   async assertClear() {
-    await this.section.expectIsClosed();
+    await this.section.expectIsOpen();
   }
 }
 

--- a/playwright/tests/inscription/parts/mail-content.ts
+++ b/playwright/tests/inscription/parts/mail-content.ts
@@ -17,7 +17,7 @@ class MailContent extends PartObject {
   }
 
   async fill() {
-    await this.section.open();
+    await this.section.expectIsOpen();
     await this.type.choose('text/html');
     await this.message.fill('Hello\nWorld');
   }
@@ -30,7 +30,7 @@ class MailContent extends PartObject {
     await this.message.clear();
   }
   async assertClear() {
-    await this.section.expectIsClosed();
+    await this.section.expectIsOpen();
   }
 }
 

--- a/playwright/tests/inscription/parts/mail-error.ts
+++ b/playwright/tests/inscription/parts/mail-error.ts
@@ -17,7 +17,7 @@ class MailError extends PartObject {
   }
 
   async fill() {
-    await this.error.toggle();
+    await this.error.expectIsOpen();
     await this.errorSelect.choose('>> Ignore Exception');
     await this.throw.click();
   }
@@ -31,7 +31,7 @@ class MailError extends PartObject {
     await this.throw.click();
   }
   async assertClear() {
-    await this.error.expectIsClosed();
+    await this.error.expectIsOpen();
   }
 }
 

--- a/playwright/tests/inscription/parts/mail-header.ts
+++ b/playwright/tests/inscription/parts/mail-header.ts
@@ -24,7 +24,7 @@ class MailHeader extends PartObject {
   }
 
   async fill() {
-    await this.headers.open();
+    await this.headers.expectIsOpen();
     await this.subject.fill('subject');
     await this.from.fill('from');
     await this.reply.fill('reply');
@@ -49,7 +49,7 @@ class MailHeader extends PartObject {
     await this.bcc.clear();
   }
   async assertClear() {
-    await this.headers.expectIsClosed();
+    await this.headers.expectIsOpen();
   }
 }
 

--- a/playwright/tests/inscription/parts/name.ts
+++ b/playwright/tests/inscription/parts/name.ts
@@ -14,7 +14,11 @@ class General extends PartObject {
   tagsSection: Section;
   tags: Tags;
 
-  constructor(part: Part, private readonly hasTags: boolean, private readonly nameDisabled?: boolean) {
+  constructor(
+    part: Part,
+    private readonly hasTags: boolean,
+    private readonly nameDisabled?: boolean
+  ) {
     super(part);
     this.nameSection = part.section('Name / Description');
     this.displayName = this.nameSection.textArea({ label: 'Display name' });
@@ -26,7 +30,7 @@ class General extends PartObject {
   }
 
   async fill() {
-    await this.nameSection.open();
+    await this.nameSection.expectIsOpen();
     if (!this.nameDisabled) {
       await this.displayName.fill('test name');
     }
@@ -62,11 +66,7 @@ class General extends PartObject {
     }
   }
   async assertClear() {
-    if (!this.nameDisabled) {
-      await this.nameSection.expectIsClosed();
-    } else {
-      await this.nameSection.expectIsOpen();
-    }
+    await this.nameSection.expectIsOpen();
     await this.meansDocumentsSection.expectIsClosed();
     if (this.hasTags) {
       await this.tags.expectEmpty();

--- a/playwright/tests/inscription/parts/output.ts
+++ b/playwright/tests/inscription/parts/output.ts
@@ -38,7 +38,10 @@ class OutputCode extends Output {
   code: ScriptArea;
   sudo: Checkbox;
 
-  constructor(part: Part, private readonly hasSudo = false) {
+  constructor(
+    part: Part,
+    private readonly hasSudo = false
+  ) {
     super(part);
     this.codeSection = part.section('Code');
     this.code = this.codeSection.scriptArea();
@@ -78,11 +81,18 @@ class OutputCode extends Output {
 
 class OutputEmptyMap extends OutputCode {
   override async assertClear() {
-    await this.mappingSection.expectIsClosed();
+    await this.mappingSection.expectIsOpen();
     await this.codeSection.expectIsClosed();
   }
 }
 
+class OutputScriptPart extends OutputCode {
+  override async assertClear() {
+    await this.mappingSection.expectIsClosed();
+    await this.codeSection.expectIsOpen();
+  }
+}
+
 export const OutputTest = new NewPartTest('Output', (part: Part) => new OutputCode(part));
-export const ScriptOutputTest = new NewPartTest('Output', (part: Part) => new OutputCode(part, true));
+export const ScriptOutputTest = new NewPartTest('Output', (part: Part) => new OutputScriptPart(part, true));
 export const SignalOutputTest = new NewPartTest('Output', (part: Part) => new OutputEmptyMap(part));

--- a/playwright/tests/inscription/parts/permissions.ts
+++ b/playwright/tests/inscription/parts/permissions.ts
@@ -7,14 +7,17 @@ class Permissions extends PartObject {
   section: Section;
   viewable: Checkbox;
 
-  constructor(part: Part, readonly defaultIsChecked: boolean) {
+  constructor(
+    part: Part,
+    readonly defaultIsChecked: boolean
+  ) {
     super(part);
     this.section = part.section('Permissions');
     this.viewable = this.section.checkbox('Allow all workflow users to view the process on the Engine');
   }
 
   async fill() {
-    await this.section.open();
+    await this.section.expectIsOpen();
     await this.viewable.click();
   }
 
@@ -31,7 +34,7 @@ class Permissions extends PartObject {
   }
 
   async assertClear() {
-    await this.section.expectIsClosed();
+    await this.section.expectIsOpen();
   }
 }
 

--- a/playwright/tests/inscription/parts/process-data.ts
+++ b/playwright/tests/inscription/parts/process-data.ts
@@ -14,7 +14,7 @@ class ProcessData extends PartObject {
   }
 
   async fill() {
-    await this.section.open();
+    await this.section.expectIsOpen();
     await this.dataClass.fill('test');
   }
 

--- a/playwright/tests/inscription/parts/program-interface-error.ts
+++ b/playwright/tests/inscription/parts/program-interface-error.ts
@@ -23,7 +23,7 @@ class ProgramInterfaceError extends PartObject {
   }
 
   async fill() {
-    await this.programSection.toggle();
+    await this.programSection.expectIsOpen();
     await this.errorProgram.choose('>> Ignore Exception');
 
     await this.timeoutSection.toggle();
@@ -48,7 +48,7 @@ class ProgramInterfaceError extends PartObject {
   }
 
   async assertClear() {
-    await this.programSection.expectIsClosed();
+    await this.programSection.expectIsOpen();
     await this.timeoutSection.expectIsClosed();
   }
 }

--- a/playwright/tests/inscription/parts/program-interface-start.ts
+++ b/playwright/tests/inscription/parts/program-interface-start.ts
@@ -14,7 +14,7 @@ class ProgramInterfaceStart extends PartObject {
   }
 
   async fill() {
-    await this.javaSection.open();
+    await this.javaSection.expectIsOpen();
     await this.javaClass.choose('ch.ivyteam.ivy.process.extension.impl.AbstractUserProcessExtension');
   }
 

--- a/playwright/tests/inscription/parts/program-start.ts
+++ b/playwright/tests/inscription/parts/program-start.ts
@@ -26,7 +26,7 @@ class ProgramStart extends PartObject {
   }
 
   async fill() {
-    await this.javaSection.open();
+    await this.javaSection.expectIsOpen();
     await this.javaClass.choose('ch.ivyteam.ivy.process.eventstart.AbstractProcessStartEventBean');
 
     await this.permissionSection.toggle();

--- a/playwright/tests/inscription/parts/query.ts
+++ b/playwright/tests/inscription/parts/query.ts
@@ -220,7 +220,10 @@ class Query extends PartObject {
   limit: LimitPart;
   definition: DefinitionPart;
 
-  constructor(part: Part, private readonly queryKind: QueryKind) {
+  constructor(
+    part: Part,
+    private readonly queryKind: QueryKind
+  ) {
     super(part);
     this.databaseSection = part.section('Database');
     this.kind = this.databaseSection.select({ label: 'Query Kind' });
@@ -250,7 +253,7 @@ class Query extends PartObject {
   }
 
   async fill() {
-    await this.databaseSection.open();
+    await this.databaseSection.expectIsOpen();
     await this.kind.choose(this.queryKind);
     await this.database.choose('IvySystemDatabase');
     for (const test of this.tests()) {

--- a/playwright/tests/inscription/parts/rest-error.ts
+++ b/playwright/tests/inscription/parts/rest-error.ts
@@ -16,7 +16,7 @@ class RestError extends PartObject {
   }
 
   async fill() {
-    await this.errorSection.toggle();
+    await this.errorSection.expectIsOpen();
     await this.clientError.choose('>> Ignore error');
     await this.statusError.choose('>> Ignore error');
   }
@@ -33,7 +33,7 @@ class RestError extends PartObject {
   }
 
   async assertClear() {
-    await this.errorSection.expectIsClosed();
+    await this.errorSection.expectIsOpen();
   }
 }
 

--- a/playwright/tests/inscription/parts/rest-output.ts
+++ b/playwright/tests/inscription/parts/rest-output.ts
@@ -24,9 +24,9 @@ class RestOutput extends PartObject {
   }
 
   async fill() {
-    await this.typeSection.open();
+    await this.typeSection.expectIsOpen();
     await this.type.fill('type');
-    await this.mappingSection.open();
+    await this.mappingSection.expectIsOpen();
     await this.mapping.row(1).column(1).fill('"bla"');
     await this.codeSection.open();
     await this.code.fill('code');
@@ -45,8 +45,8 @@ class RestOutput extends PartObject {
   }
 
   async assertClear() {
-    await this.typeSection.expectIsClosed();
-    await this.mappingSection.expectIsClosed();
+    await this.typeSection.expectIsOpen();
+    await this.mappingSection.expectIsOpen();
     await this.codeSection.expectIsClosed();
   }
 }

--- a/playwright/tests/inscription/parts/rest-request-body.ts
+++ b/playwright/tests/inscription/parts/rest-request-body.ts
@@ -15,7 +15,11 @@ class EntityPart extends PartObject {
   mapping: Table;
   code: ScriptArea;
 
-  constructor(part: Part, body: Section, readonly openApiMode = false) {
+  constructor(
+    part: Part,
+    body: Section,
+    readonly openApiMode = false
+  ) {
     super(part);
     this.bodyType = body.radioGroup();
     this.entityType = body.combobox('Entity-Type');
@@ -125,7 +129,10 @@ class RestRequestBody extends PartObject {
   rawPart: RawPart;
   contentType: Combobox;
 
-  constructor(part: Part, readonly type: InputType = 'ENTITY') {
+  constructor(
+    part: Part,
+    readonly type: InputType = 'ENTITY'
+  ) {
     super(part);
     this.openapiSwitch = part.currentLocator().getByRole('switch', { name: 'OpenAPI' });
     this.serviceSection = part.section('Rest Service');
@@ -210,7 +217,7 @@ class RestRequestBodyOpenApi extends RestRequestBody {
   }
 
   override async fill() {
-    await this.serviceSection.open();
+    await this.serviceSection.expectIsOpen();
     await this.client.choose('pet');
     await expect(this.openapiSwitch).toBeVisible();
     await this.resource.choose('POST');

--- a/playwright/tests/inscription/parts/rest-request.ts
+++ b/playwright/tests/inscription/parts/rest-request.ts
@@ -43,7 +43,7 @@ class RestRequest extends PartObject {
   }
 
   async fill() {
-    await this.serviceSection.open();
+    await this.serviceSection.expectIsOpen();
     await expect(this.targetUrl).toBeHidden();
     await this.client.choose('stock');
     await this.method.choose('POST');
@@ -113,7 +113,7 @@ class RestRequest extends PartObject {
 
 class RestRequestOpenApi extends RestRequest {
   override async fill() {
-    await this.serviceSection.open();
+    await this.serviceSection.expectIsOpen();
     await this.client.choose('pet');
     await expect(this.openapiSwitch).toBeVisible();
     await this.resource.choose('DELETE');

--- a/playwright/tests/inscription/parts/result.ts
+++ b/playwright/tests/inscription/parts/result.ts
@@ -12,7 +12,10 @@ class Result extends PartObject {
   codeSection: Section;
   code: ScriptArea;
 
-  constructor(part: Part, private readonly hideParamDesc: boolean = false) {
+  constructor(
+    part: Part,
+    private readonly hideParamDesc: boolean = false
+  ) {
     super(part);
     this.paramSection = part.section('Result parameters');
     if (this.hideParamDesc) {
@@ -35,7 +38,7 @@ class Result extends PartObject {
       await paramRow.fill(['param', 'String', 'desc']);
     }
     await this.paramSection.toggle();
-    await this.mappingSection.open();
+    await this.mappingSection.expectIsOpen();
     await this.mapping.row(1).column(1).fill('"bla"');
     await this.codeSection.open();
     await this.code.fill('code');

--- a/playwright/tests/inscription/parts/signal-catch.ts
+++ b/playwright/tests/inscription/parts/signal-catch.ts
@@ -11,7 +11,10 @@ class SignalCatch extends PartObject {
   signalMacro: MacroEditor;
   attach: Checkbox;
 
-  constructor(part: Part, private readonly makroSupport: boolean = false) {
+  constructor(
+    part: Part,
+    private readonly makroSupport: boolean = false
+  ) {
     super(part);
     this.section = part.section('Signal Code');
     this.signal = this.section.combobox();
@@ -20,7 +23,7 @@ class SignalCatch extends PartObject {
   }
 
   async fill() {
-    await this.section.open();
+    await this.section.expectIsOpen();
     if (!this.makroSupport) {
       await this.signal.fill('test:signal');
       await this.attach.click();
@@ -48,7 +51,7 @@ class SignalCatch extends PartObject {
   }
 
   async assertClear() {
-    await this.section.expectIsClosed();
+    await this.section.expectIsOpen();
   }
 }
 

--- a/playwright/tests/inscription/parts/start.ts
+++ b/playwright/tests/inscription/parts/start.ts
@@ -15,7 +15,10 @@ class Start extends PartObject {
   codeSection: Section;
   code: ScriptArea;
 
-  constructor(part: Part, private readonly hideParamDesc: boolean = false) {
+  constructor(
+    part: Part,
+    private readonly hideParamDesc: boolean = false
+  ) {
     super(part);
     this.signatureSection = part.section('Signature');
     this.signature = this.signatureSection.textArea({});
@@ -42,7 +45,7 @@ class Start extends PartObject {
       await paramRow.fill(['param', 'String', 'desc']);
     }
     await this.paramSection.toggle();
-    await this.mappingSection.open();
+    await this.mappingSection.expectIsOpen();
     await this.mapping.row(1).column(1).fill('"bla"');
     await this.codeSection.open();
     await this.code.fill('code');
@@ -76,7 +79,7 @@ class Start extends PartObject {
     await this.paramSection.toggle();
     await this.params.expectEmpty();
     await this.paramSection.toggle();
-    await this.mappingSection.expectIsClosed();
+    await this.mappingSection.expectIsOpen();
     await this.codeSection.expectIsClosed();
   }
 }

--- a/playwright/tests/inscription/parts/trigger.ts
+++ b/playwright/tests/inscription/parts/trigger.ts
@@ -15,7 +15,7 @@ class Trigger extends PartObject {
   constructor(part: Part) {
     super(part);
     this.triggerable = part.checkbox('Yes, this can be started with a Trigger Activity');
-    this.responsible = part.responsibleSection();
+    this.responsible = part.responsibleSection(true);
     this.options = part.section('Options');
     this.attach = part.checkbox('Attach to Business Case that triggered this process');
     this.delay = part.scriptInput('Delay');

--- a/playwright/tests/inscription/parts/web-service.ts
+++ b/playwright/tests/inscription/parts/web-service.ts
@@ -27,7 +27,7 @@ class WebService extends PartObject {
   }
 
   async fill() {
-    await this.permissionSection.toggle();
+    await this.permissionSection.expectIsOpen();
     await this.roles.chooseTags(['Support']);
     await this.error.choose('>> Ignore Exception');
 
@@ -58,7 +58,7 @@ class WebService extends PartObject {
   }
 
   async assertClear() {
-    await this.permissionSection.expectIsClosed();
+    await this.permissionSection.expectIsOpen();
     await this.exceptionSection.expectIsClosed();
   }
 }

--- a/playwright/tests/inscription/parts/ws-error.ts
+++ b/playwright/tests/inscription/parts/ws-error.ts
@@ -14,7 +14,7 @@ class WsError extends PartObject {
   }
 
   async fill() {
-    await this.errorSection.toggle();
+    await this.errorSection.expectIsOpen();
     await this.exception.choose('>> Ignore Exception');
   }
 
@@ -28,7 +28,7 @@ class WsError extends PartObject {
   }
 
   async assertClear() {
-    await this.errorSection.expectIsClosed();
+    await this.errorSection.expectIsOpen();
   }
 }
 

--- a/playwright/tests/inscription/parts/ws-output.ts
+++ b/playwright/tests/inscription/parts/ws-output.ts
@@ -19,7 +19,7 @@ class WsOutput extends PartObject {
   }
 
   async fill() {
-    await this.mappingSection.open();
+    await this.mappingSection.expectIsOpen();
     await this.mapping.row(1).column(1).fill('"bla"');
     await this.codeSection.open();
     await this.code.fill('code');

--- a/playwright/tests/inscription/parts/ws-request.ts
+++ b/playwright/tests/inscription/parts/ws-request.ts
@@ -27,7 +27,7 @@ class WsRequest extends PartObject {
   }
 
   async fill() {
-    await this.serviceSection.open();
+    await this.serviceSection.expectIsOpen();
     await this.client.choose('GeoIpService');
     await this.port.choose('GeoIPServiceSoap');
     await this.operation.choose('GetGeoIP');

--- a/playwright/tests/inscription/widgets/code-editor.spec.ts
+++ b/playwright/tests/inscription/widgets/code-editor.spec.ts
@@ -18,7 +18,7 @@ test.describe('Code Editor', () => {
   test('MacroInput', async () => {
     const taskPart = view.inscriptionTab('Task');
     await taskPart.open();
-    const details = taskPart.section('Details');
+    const details = taskPart.section('Name / Description');
     await details.open();
     const name = details.macroInput('Name');
     await name.triggerContentAssist();
@@ -28,7 +28,7 @@ test.describe('Code Editor', () => {
   test('MacroArea', async () => {
     const taskPart = view.inscriptionTab('Task');
     await taskPart.open();
-    const details = taskPart.section('Details');
+    const details = taskPart.section('Name / Description');
     await details.open();
     const description = details.macroArea('Description');
     await description.triggerContentAssist();

--- a/playwright/tests/page-objects/inscription/code-editor.ts
+++ b/playwright/tests/page-objects/inscription/code-editor.ts
@@ -6,7 +6,12 @@ class CodeEditor {
   private readonly code: Locator;
   private readonly scriptArea: Locator;
 
-  constructor(readonly page: Page, readonly locator: Locator, readonly value: Locator, readonly parentLocator: Locator) {
+  constructor(
+    readonly page: Page,
+    readonly locator: Locator,
+    readonly value: Locator,
+    readonly parentLocator: Locator
+  ) {
     this.contentAssist = parentLocator.locator('div.suggest-widget');
     this.code = parentLocator.locator('div.code-input').first();
     this.scriptArea = parentLocator.locator('div.script-area');
@@ -75,6 +80,7 @@ class CodeEditor {
       await this.page.keyboard.press('Control+KeyA');
     }
     await this.page.keyboard.press('Delete');
+    await expect(this.code).toHaveText('');
   }
 
   async expectValue(value: string) {

--- a/playwright/tests/page-objects/inscription/info-component.ts
+++ b/playwright/tests/page-objects/inscription/info-component.ts
@@ -9,14 +9,14 @@ export class InfoComponent {
   category: MacroEditor;
 
   constructor(readonly part: Part) {
-    this.detailSection = part.section('Details');
+    this.detailSection = part.section('Name / Description');
     this.name = this.detailSection.macroInput('Name');
-    this.description = this.part.macroArea('Description');
-    this.category = this.part.macroInput('Category');
+    this.description = this.detailSection.macroArea('Description');
+    this.category = this.detailSection.macroInput('Category');
   }
 
   async fill(name = 'info name') {
-    await this.detailSection.open();
+    await this.detailSection.expectIsOpen();
     await this.name.fill(name);
     await this.description.fill('info desc');
     await this.category.fill('info cat');
@@ -35,6 +35,9 @@ export class InfoComponent {
   }
 
   async expectEmpty() {
-    await this.detailSection.expectIsClosed();
+    await this.detailSection.expectIsOpen();
+    await this.name.expectEmpty();
+    await this.description.expectEmpty();
+    await this.category.expectEmpty();
   }
 }

--- a/playwright/tests/page-objects/inscription/part.ts
+++ b/playwright/tests/page-objects/inscription/part.ts
@@ -16,7 +16,7 @@ export abstract class Part extends Composite {
     return new ResponsibleComponent(this);
   }
 
-  responsibleSection() {
-    return new ResponsibleSection(this);
+  responsibleSection(defaultOpen: boolean = false) {
+    return new ResponsibleSection(this, defaultOpen);
   }
 }

--- a/playwright/tests/page-objects/inscription/responsible-component.ts
+++ b/playwright/tests/page-objects/inscription/responsible-component.ts
@@ -59,9 +59,11 @@ export class ResponsibleComponent {
 
 export class ResponsibleSection extends ResponsibleComponent {
   readonly section: Section;
+  readonly defaultOpen: boolean;
 
-  constructor(part: Part | Section) {
+  constructor(part: Part | Section, defaultOpen: boolean = false) {
     super(part);
+    this.defaultOpen = defaultOpen;
     this.section = part.section('Responsible');
     this.typeSelect = this.section.select({ nth: 0 });
     this.script = this.section.scriptInput();
@@ -81,6 +83,10 @@ export class ResponsibleSection extends ResponsibleComponent {
   }
 
   override async expectEmpty() {
-    await this.section.expectIsClosed();
+    if (this.defaultOpen) {
+      await this.section.expectIsOpen();
+    } else {
+      await this.section.expectIsClosed();
+    }
   }
 }

--- a/playwright/tests/page-objects/inscription/table.ts
+++ b/playwright/tests/page-objects/inscription/table.ts
@@ -9,7 +9,12 @@ export class Table {
   private readonly header: Locator;
   private readonly locator: Locator;
 
-  constructor(readonly page: Page, parentLocator: Locator, readonly columns: ColumnType[], label?: string) {
+  constructor(
+    readonly page: Page,
+    parentLocator: Locator,
+    readonly columns: ColumnType[],
+    label?: string
+  ) {
     if (label === undefined) {
       this.locator = parentLocator;
     } else {
@@ -57,7 +62,13 @@ export class Row {
   public readonly locator: Locator;
   public readonly header: Locator;
 
-  constructor(readonly page: Page, rowsLocator: Locator, headerLocator: Locator, row: number, readonly columns: ColumnType[]) {
+  constructor(
+    readonly page: Page,
+    rowsLocator: Locator,
+    headerLocator: Locator,
+    row: number,
+    readonly columns: ColumnType[]
+  ) {
     this.locator = rowsLocator.nth(row);
     this.header = headerLocator.nth(0);
   }
@@ -108,7 +119,12 @@ export class Cell {
   private readonly select: Select;
   private readonly combobox: Combobox;
 
-  constructor(readonly page: Page, rowLocator: Locator, column: number, readonly columnType: ColumnType) {
+  constructor(
+    readonly page: Page,
+    rowLocator: Locator,
+    column: number,
+    readonly columnType: ColumnType
+  ) {
     this.locator = rowLocator.getByRole('cell').nth(column);
     this.textbox = this.locator.getByRole('textbox');
     this.select = new Select(page, this.locator);

--- a/playwright/tests/screenshots/inscription/scripting.spec.ts
+++ b/playwright/tests/screenshots/inscription/scripting.spec.ts
@@ -36,7 +36,7 @@ test.describe('Scripting', () => {
   test('Macro', async ({ page }) => {
     await page.setViewportSize({ width: 500, height: 600 });
     const inscriptionTab = await openInscriptionTab(page, GENERIC_PID.USER_TASK, 'Task');
-    const section = inscriptionTab.section('Details');
+    const section = inscriptionTab.section('Name / Description');
     await section.open();
     const script = section.macroArea('Name');
 


### PR DESCRIPTION
I've now adjusted the default behavior of the collapsibles. In general I followed the following principals:
- If a tab contains only one collapsible, it is always open.
- By default, only one table may be open at a time.

The tabs that are always open by default are defined here:
https://1ivy.atlassian.net/wiki/spaces/XIVY/pages/774471703/Inscription+View+Default+Opened+Collapsible

In a later PR i will improve the height of the Code/Mail-Content/SQL-Query