### PR TITLE
XIVY-6822 Improve undo/redo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17684,7 +17684,8 @@
         "@axonivy/ui-icons": "~13.2.0-next",
         "i18next": "^24.2.3 || ^25.0.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-i18next": "^15.4.1"
       }
     },
     "packages/inscription": {
@@ -17745,7 +17746,7 @@
         "@axonivy/process-editor-inscription-core": "~13.2.0-next",
         "@axonivy/process-editor-inscription-protocol": "~13.2.0-next",
         "@monaco-editor/react": "^4.7.0",
-        "@tanstack/react-virtual": "^3.13.11",
+        "@tanstack/react-virtual": "^3.11.2",
         "immer": "^10.1.1",
         "react-aria": "^3.38.0",
         "react-error-boundary": "^6.0.0"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -27,6 +27,7 @@
     "@axonivy/ui-components": "~13.2.0-next",
     "@axonivy/ui-icons": "~13.2.0-next",
     "i18next": "^24.2.3 || ^25.0.0",
+    "react-i18next": "^15.4.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/editor/src/translation/process-editor/de.json
+++ b/packages/editor/src/translation/process-editor/de.json
@@ -172,6 +172,7 @@
     "clickToReload": "{{message}} (Zum Aktualisieren klicken)",
     "connectionClosed": "Verbindung zum Server wurde geschlossen.",
     "connectionToServerError": "Verbindung zum Server fehlerhaft. Server wird heruntergefahren.",
+    "elementOpen": "Element öffnen",
     "globalError": "Ein Fehler ist aufgetreten: {{error}}",
     "noEditorForType": "Kein Editor für Typ gefunden: {{props.type}}",
     "noNativeClipboardAccess": "Kein Zugriff auf das native Clipboard, Kopieren funktioniert nur in diesem Editor.",

--- a/packages/editor/src/translation/process-editor/en.json
+++ b/packages/editor/src/translation/process-editor/en.json
@@ -172,6 +172,7 @@
     "clickToReload": "{{message}} (Click to reload)",
     "connectionClosed": "Connection to server got closed.",
     "connectionToServerError": "Connection to server is erroring. Shutting down server.",
+    "elementOpen": "Open Element",
     "globalError": "An error occurred: {{error}}",
     "noEditorForType": "No editor found for type: {{props.type}}",
     "noNativeClipboardAccess": "Could not access native clipboard, copy will only work in same editor.",

--- a/packages/editor/src/ui-tools/notification/di.config.ts
+++ b/packages/editor/src/ui-tools/notification/di.config.ts
@@ -10,6 +10,7 @@ import {
   TYPES
 } from '@eclipse-glsp/client';
 import { NotificationToaster } from './notification-toaster';
+import { ElementMessageAction } from '@axonivy/process-editor-protocol';
 
 export const ivyNotificationModule = new FeatureModule((bind, unbind, isBound, rebind) => {
   const context = { bind, unbind, isBound, rebind };
@@ -19,6 +20,7 @@ export const ivyNotificationModule = new FeatureModule((bind, unbind, isBound, r
   configureActionHandler(context, StartProgressAction.KIND, NotificationToaster);
   configureActionHandler(context, UpdateProgressAction.KIND, NotificationToaster);
   configureActionHandler(context, EndProgressAction.KIND, NotificationToaster);
+  configureActionHandler(context, ElementMessageAction.KIND, NotificationToaster);
 });
 
 export const NotificationToasterId = NotificationToaster.ID;

--- a/packages/editor/src/ui-tools/tool-bar/button.ts
+++ b/packages/editor/src/ui-tools/tool-bar/button.ts
@@ -1,14 +1,5 @@
 import { IvyIcons } from '@axonivy/ui-icons';
-import {
-  Action,
-  EnableDefaultToolsAction,
-  EnableToolsAction,
-  type IGridManager,
-  MarqueeMouseTool,
-  RedoAction,
-  TYPES,
-  UndoAction
-} from '@eclipse-glsp/client';
+import { Action, EnableDefaultToolsAction, EnableToolsAction, type IGridManager, MarqueeMouseTool, TYPES } from '@eclipse-glsp/client';
 import { inject, injectable } from 'inversify';
 import { ShowToolBarOptionsMenuAction } from './options/action';
 import { CustomIconToggleActionHandler } from './options/action-handler';
@@ -66,24 +57,6 @@ export const MarqueeToolButton = (): ToolBarButton => ({
   location: ToolBarButtonLocation.Left,
   readonly: true,
   switchFocus: true
-});
-
-export const UndoToolButton = (): ToolBarButton => ({
-  icon: IvyIcons.Undo,
-  title: t('toolbar.undo'),
-  sorting: 'C',
-  action: () => UndoAction.create(),
-  id: 'btn_undo_tools',
-  location: ToolBarButtonLocation.Left
-});
-
-export const RedoToolButton = (): ToolBarButton => ({
-  icon: IvyIcons.Redo,
-  title: t('toolbar.redo'),
-  sorting: 'D',
-  action: () => RedoAction.create(),
-  id: 'btn_redo_tools',
-  location: ToolBarButtonLocation.Left
 });
 
 @injectable()

--- a/packages/editor/src/ui-tools/tool-bar/edit-buttons.tsx
+++ b/packages/editor/src/ui-tools/tool-bar/edit-buttons.tsx
@@ -1,0 +1,29 @@
+import { Button, Flex } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import { GArgument, RedoAction, UndoAction, type GModelRoot, type IActionDispatcher } from '@eclipse-glsp/client';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const EditButtons = ({ root, dispatcher }: { root: Readonly<GModelRoot>; dispatcher: IActionDispatcher }) => {
+  const { t } = useTranslation();
+  return (
+    <Flex gap={1} className='edit-buttons'>
+      <Button
+        id='btn_undo_tools'
+        title={t('toolbar.undo')}
+        icon={IvyIcons.Undo}
+        size='large'
+        onClick={() => dispatcher.dispatch(UndoAction.create())}
+        disabled={GArgument.getArgument(root, 'canUndo') !== true}
+      />
+      <Button
+        id='btn_redo_tools'
+        title={t('toolbar.redo')}
+        icon={IvyIcons.Redo}
+        size='large'
+        onClick={() => dispatcher.dispatch(RedoAction.create())}
+        disabled={GArgument.getArgument(root, 'canRedo') !== true}
+      />
+    </Flex>
+  );
+};

--- a/packages/editor/src/ui-tools/tool-bar/tool-bar.css
+++ b/packages/editor/src/ui-tools/tool-bar/tool-bar.css
@@ -11,38 +11,9 @@
 .tool-bar-header .middle-buttons {
   z-index: 10;
 }
-.tool-bar-header .middle-buttons .tool-bar-title-button {
-  min-width: 60px;
-}
-.tool-bar-header .tool-bar-button {
-  height: 30px;
-}
-.tool-bar-header .tool-bar-title-button {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-.tool-bar-header .tool-bar-title-button > label {
-  font-size: 10px;
-  margin-bottom: 0.125rem;
-  color: var(--N900, var(--glsp-tool-border));
-}
-.tool-bar-header .tool-bar-title-button .tool-bar-button {
-  max-height: 24px;
-}
-.tool-bar-header .tool-bar-button i {
-  color: var(--body, --var(--glsp-tool-button));
-}
-.tool-bar-header .tool-bar-title-button .tool-bar-button i.ivy-chevron {
-  transform: rotate(90deg);
-}
-.tool-bar-header .tool-bar-button.clicked,
-.tool-bar-header .tool-bar-button:hover {
-  background: var(--glsp-tool-bar-button-active-bg);
-}
 
 @container toolbar (max-width: 650px) {
-  .tool-bar-header .middle-buttons .tool-bar-title-button:not(:first-child) {
+  .tool-bar-header .middle-buttons > .ui-flex:not(:first-child) {
     display: none;
   }
 }

--- a/packages/protocol/src/action/message.ts
+++ b/packages/protocol/src/action/message.ts
@@ -1,0 +1,18 @@
+import { Action, hasStringProp } from '@eclipse-glsp/protocol';
+import type { CreateOptionHelper } from '../type-helper';
+
+export interface ElementMessageAction extends Action {
+  kind: typeof ElementMessageAction.KIND;
+  message: string;
+  elementId: string;
+}
+
+export namespace ElementMessageAction {
+  export const KIND = 'elementMessage';
+
+  export function is(object: unknown): object is ElementMessageAction {
+    return Action.hasKind(object, KIND) && hasStringProp(object, 'elementId') && hasStringProp(object, 'message');
+  }
+
+  export const create: CreateOptionHelper<ElementMessageAction> = options => ({ kind: KIND, ...options });
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -11,6 +11,7 @@ export * from './action/execution';
 export * from './action/form-editor';
 export * from './action/go-to-source';
 export * from './action/jump';
+export * from './action/message';
 export * from './action/model';
 export * from './action/outline';
 export * from './action/palette-items';

--- a/packages/protocol/src/type-helper.ts
+++ b/packages/protocol/src/type-helper.ts
@@ -1,0 +1,3 @@
+import type { Action } from '@eclipse-glsp/protocol';
+
+export type CreateOptionHelper<T extends Action> = (options: Omit<T, 'kind'>) => T;

--- a/playwright/tests/page-objects/editor/process-editor.ts
+++ b/playwright/tests/page-objects/editor/process-editor.ts
@@ -100,8 +100,8 @@ export class ProcessEditor {
     return ProcessEditor.inscriptionView(this.page);
   }
 
-  async expectToastToContainText(text: string) {
-    await expect(this.page.locator('.ivy-notification-toaster li').first()).toContainText(text);
+  get toast() {
+    return this.page.locator('.ivy-notification-toaster li').first();
   }
 
   public static inscriptionView(page: Page) {

--- a/playwright/tests/page-objects/editor/toolbar.ts
+++ b/playwright/tests/page-objects/editor/toolbar.ts
@@ -50,12 +50,12 @@ export class Toolbar {
     await this.expectActiveButton('default_tools');
   }
 
-  async triggerUndo() {
-    await this.toolbar.locator('#btn_undo_tools').click();
+  undoButton() {
+    return this.toolbar.locator('#btn_undo_tools');
   }
 
-  async triggerRedo() {
-    await this.toolbar.locator('#btn_redo_tools').click();
+  redoButton() {
+    return this.toolbar.locator('#btn_redo_tools');
   }
 
   async triggerOptions() {
@@ -91,16 +91,16 @@ export class Toolbar {
   }
 
   async expectActiveButton(button: MenuBtn | ToolBtn) {
-    const activeBtn = this.toolbar.locator('.tool-bar-button.clicked');
+    const activeBtn = this.toolbar.locator('button[data-state="on"]');
     await expect(activeBtn).toHaveCount(1);
-    await expect(this.toolbar.locator('.tool-bar-button.clicked')).toHaveId(`btn_${button}`);
+    await expect(this.toolbar.locator('button[data-state="on"]')).toHaveId(`btn_${button}`);
   }
 
   async expectEditMode() {
     await expect(this.defaultTool).toBeVisible();
     await expect(this.optionsBtn).toBeVisible();
     await expect(this.toolbar.locator('.edit-buttons')).toBeVisible();
-    await expect(this.toolbar.locator('.middle-buttons > span')).toHaveCount(6);
+    await expect(this.toolbar.locator('.middle-buttons button')).toHaveCount(6);
   }
 
   async expectReadonly() {

--- a/playwright/tests/standalone/diagram/element.spec.ts
+++ b/playwright/tests/standalone/diagram/element.spec.ts
@@ -84,7 +84,7 @@ test('increase and decrease element size using shortcut', async ({ page }) => {
   await element.expectPosition({ x: 248, y: 170 });
   await element.expectSize(112, 60);
   await page.keyboard.press('Alt+KeyA');
-  await processEditor.expectToastToContainText('Resize On:');
+  await expect(processEditor.toast).toContainText('Resize On:');
   await processEditor.page.keyboard.press('+');
   await element.expectPosition({ x: 248, y: 170 });
   await element.expectSize(120, 68);
@@ -92,5 +92,5 @@ test('increase and decrease element size using shortcut', async ({ page }) => {
   await element.expectPosition({ x: 248, y: 170 });
   await element.expectSize(112, 60);
   await page.keyboard.press('Escape');
-  await processEditor.expectToastToContainText('Resize Off:');
+  await expect(processEditor.toast).toContainText('Resize Off:');
 });

--- a/playwright/tests/standalone/key-listener/copy-paste.spec.ts
+++ b/playwright/tests/standalone/key-listener/copy-paste.spec.ts
@@ -40,6 +40,6 @@ test('paste raw text show toast', async ({ page, browserName }) => {
   await page.keyboard.press(`${cmdCtrl()}+C`);
   await page.keyboard.press('Escape');
   await page.keyboard.press(`${cmdCtrl(browserName)}+V`);
-  await processEditor.expectToastToContainText('Paste clipboard data does not match the process data format.');
+  await expect(processEditor.toast).toContainText('Paste clipboard data does not match the process data format.');
   await expect(start.locator()).toHaveCount(1);
 });

--- a/playwright/tests/standalone/viewport/accessibility.spec.ts
+++ b/playwright/tests/standalone/viewport/accessibility.spec.ts
@@ -84,10 +84,10 @@ test('element navigation mode', async ({ page }) => {
   const editor = await ProcessEditor.openProcess(page);
   await editor.startElement.select();
   await page.keyboard.press('N');
-  await editor.expectToastToContainText('Navigation On:');
+  await expect(editor.toast).toContainText('Navigation On:');
   await page.keyboard.press('ArrowRight');
   await page.keyboard.press('ArrowRight');
   await editor.endElement.expectSelected();
   await page.keyboard.press('Escape');
-  await editor.expectToastToContainText('Navigation Off:');
+  await expect(editor.toast).toContainText('Navigation Off:');
 });


### PR DESCRIPTION
- Show toast when undo/redo element config, with button to open inscription
- Refactor toolbar buttons a bit to reuse ui-component styles
  - We could go further here, I think we sould get rid of register buttons or at least only those wo are dynamic

First solution example, did it with a toast because:
- Do to much when undo/redo maybe could be confusing (open inscription or select element or etc)
- Now you get a message with the option to open the element, which I find a good compromise

![Screen Recording 2025-07-03 at 15 40 27](https://github.com/user-attachments/assets/233b29f9-37dd-4877-940c-238e0950128d)
