### PR TITLE
XIVY-17023 Fix apply of MaximizedCodeEditor for MacroArea

### DIFF
--- a/packages/inscription-view/src/components/widgets/code-editor/MacroArea.tsx
+++ b/packages/inscription-view/src/components/widgets/code-editor/MacroArea.tsx
@@ -30,7 +30,7 @@ export const MacroArea = ({ value, onChange, minHeight, browsers, ...props }: Co
               browsers={browsers}
               editorValue={value}
               location={path}
-              applyEditor={focusValue.onChange}
+              applyEditor={onChange}
               selectionRange={getSelectionRange()}
               header={props.maximizedHeader}
               macro={true}
@@ -54,7 +54,7 @@ export const MacroArea = ({ value, onChange, minHeight, browsers, ...props }: Co
       ) : (
         <InputBadgeArea
           badgeProps={badgePropsExpression}
-          value={focusValue.value}
+          value={value}
           tabIndex={0}
           {...inputProps}
           {...props}


### PR DESCRIPTION
I noticed that when editing the MacroArea using the Maximized Code Editor, any changes made, applied, and then followed by a page reload are not saved. With this fix, it appears to be working correctly again.