### PR TITLE
Remove unused edit label validation > R12

### DIFF
--- a/packages/editor/src/edit-label/di.config.ts
+++ b/packages/editor/src/edit-label/di.config.ts
@@ -2,10 +2,8 @@ import './edit-label.css';
 
 import {
   ApplyLabelEditCommand,
-  BalloonLabelValidationDecorator,
   EditLabelAction,
   FeatureModule,
-  ServerEditLabelValidator,
   TYPES,
   bindAsService,
   configureActionHandler,
@@ -22,8 +20,8 @@ export const ivyLabelEditModule = new FeatureModule(
   (bind, _unbind, isBound) => {
     // GLSP defaults
     configureCommand({ bind, isBound }, ApplyLabelEditCommand);
-    bind(TYPES.IEditLabelValidator).to(ServerEditLabelValidator);
-    bind(TYPES.IEditLabelValidationDecorator).to(BalloonLabelValidationDecorator);
+    // bind(TYPES.IEditLabelValidator).to(ServerEditLabelValidator);
+    // bind(TYPES.IEditLabelValidationDecorator).to(BalloonLabelValidationDecorator);
 
     // GLSP replacements
     bindAsService(bind, TYPES.IDefaultTool, IvyDirectLabelEditTool);


### PR DESCRIPTION
- This will also remove the warning logs from the ivy.yaml `No validator registered for the context 'label-edit'`

https://github.com/axonivy/process-editor/pull/1130