### PR TITLE
Add delete button to unkown mapping column

### DIFF
--- a/packages/inscription-view/src/components/widgets/table/cell/ScriptCell.tsx
+++ b/packages/inscription-view/src/components/widgets/table/cell/ScriptCell.tsx
@@ -1,4 +1,5 @@
-import { InputCell } from '@axonivy/ui-components';
+import { Button, Flex, InputCell } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
 import type { CellContext } from '@tanstack/react-table';
 import type { BrowserType } from '../../../browser/useBrowser';
 import { CodeEditorCell } from './CodeEditorCell';
@@ -16,9 +17,18 @@ export const ScriptCell = <TData,>({
 }) => {
   if (type === undefined || type.length === 0) {
     return (
-      <div className='code-input'>
+      <Flex
+        justifyContent='space-between'
+        alignItems='center'
+        gap={1}
+        className='code-input'
+        style={{
+          paddingRight: 'var(--size-1)'
+        }}
+      >
         <InputCell className='script-cell view-lines' cell={cell} placeholder={placeholder} />
-      </div>
+        <Button icon={IvyIcons.Trash} onClick={() => cell.table.options.meta?.updateData(cell.row.id, cell.column.id, '')} />
+      </Flex>
     );
   }
   return <CodeEditorCell cell={cell} macro={false} type={type} browsers={browsers} placeholder={placeholder} />;


### PR DESCRIPTION
There is an issue (only in VS Code) where an attribute that was previously defined but no longer exists is still correctly flagged as an error. However, when trying to edit the expression, I can focus the input field, but any attempt to delete or modify the content has no effect, making it impossible to remove or change the value in that column.

Unfortunately, I was unable to reproduce this issue in either Firefox or Chrome, which made it difficult to identify the root cause. After consulting AI, I was advised that the issue might be related to not always using the CodeEditorCell within the ScriptCell. The InputCell uses, when the type is unknown or empty, just a basic controlled React input. In the VS Code webview (Electron), this plain input may lose keyboard functionality.

However, I am not fully convinced that this is the actual cause. As a workaround, I have added a trash button to the ScriptCell for unknown types, which clears the cell content and effectively removes it. What do you think?

<img width="1152" height="1094" alt="grafik" src="https://github.com/user-attachments/assets/79159be3-031e-4ba1-a783-d2f080771466" />
