### PR TITLE
build: use Axon Ivy dist-tags for next deps

### DIFF
--- a/.ivy/raise-deps.sh
+++ b/.ivy/raise-deps.sh
@@ -7,18 +7,19 @@ if [ -z "$1" ]; then
 fi
 
 VERSION="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/version-helper.sh"
+
+NEXT_VERSION="$(to_next_version "$VERSION")"
+NEXT_TAG="$(to_next_tag "$VERSION")"
 
 update_version() {
-  local version="${1/SNAPSHOT/next}"
-  sed -i -E "s/(\"@axonivy[^\"]*\": \"(workspace:)?)[^\"]*(\")/\1~$version\3/" "$2"
+  sed -i -E \
+    -e "s/(\"@axonivy[^\"]*\": \")~[0-9]+\.[0-9]+\.[0-9]+-next(\.[0-9]+\.[a-f0-9]+)?(\")/\1~$NEXT_VERSION\3/" \
+    -e "s/(\"@axonivy[^\"]*\": \")next-[0-9]+\.[0-9]+\.[0-9]+(\")/\1$NEXT_TAG\2/" \
+    "$1"
 }
 
 for pkg in packages/*/package.json integration/*/package.json package.json; do
-  update_version "$VERSION" "$pkg"
+  update_version "$pkg"
 done
-
-pnpm run update:axonivy:next
-
-if [ "$DRY_RUN" = false ]; then
-  pnpm install --no-frozen-lockfile
-fi

--- a/.ivy/raise-version.sh
+++ b/.ivy/raise-version.sh
@@ -1,12 +1,25 @@
 #!/bin/bash
 set -e
 
-mvn --batch-mode -f integration/eclipse/pom.xml versions:set versions:commit -DnewVersion=${1}
-mvn --batch-mode -f integration/viewer/pom.xml versions:set versions:commit -DnewVersion=${1}
-mvn --batch-mode -f playwright/process-test-project/pom.xml versions:set versions:commit -DnewVersion=${1}
-mvn --batch-mode -f playwright/inscription-test-project/pom.xml versions:set versions:commit -DnewVersion=${1}
-mvn --batch-mode -f playwright/tests/screenshots/pom.xml versions:set versions:commit -DnewVersion=${1}
+if [ -z "$1" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+VERSION="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/version-helper.sh"
+
+NEXT_VERSION="$(to_next_version "$VERSION")"
+NEXT_TAG="$(to_next_tag "$VERSION")"
+
+mvn --batch-mode -f integration/eclipse/pom.xml versions:set versions:commit -DnewVersion="$VERSION"
+mvn --batch-mode -f integration/viewer/pom.xml versions:set versions:commit -DnewVersion="$VERSION"
+mvn --batch-mode -f playwright/process-test-project/pom.xml versions:set versions:commit -DnewVersion="$VERSION"
+mvn --batch-mode -f playwright/inscription-test-project/pom.xml versions:set versions:commit -DnewVersion="$VERSION"
+mvn --batch-mode -f playwright/tests/screenshots/pom.xml versions:set versions:commit -DnewVersion="$VERSION"
 
 pnpm install
-pnpm run raise:version ${1/SNAPSHOT/next}
+pnpm run raise:version "$NEXT_VERSION"
+sed -i -E "s/(--pre-dist-tag )next-[0-9]+\.[0-9]+\.[0-9]+/\1$NEXT_TAG/" package.json
 pnpm install --no-frozen-lockfile

--- a/.ivy/version-helper.sh
+++ b/.ivy/version-helper.sh
@@ -1,0 +1,7 @@
+to_next_version() {
+  echo "${1/SNAPSHOT/next}"
+}
+
+to_next_tag() {
+  echo "next-${1%-SNAPSHOT}"
+}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@axonivy:registry=https://npmjs-registry.ivyteam.ch/

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -16,8 +16,8 @@ pipeline {
         script {
           catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
             docker.build('node', '-f build/Dockerfile.node .').inside {
-              sh 'pnpm run update:axonivy:next'
-              sh 'pnpm install --no-frozen-lockfile && pnpm run build && pnpm run package'
+              sh 'pnpm install && pnpm run update:axonivy:next'
+              sh 'pnpm run build && pnpm run package'
               sh 'pnpm run check'
             }
           }

--- a/build/integration/Jenkinsfile
+++ b/build/integration/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
       steps {
         script {
           docker.build('node-webtest', '-f build/Dockerfile.playwright .').inside {
-            sh 'pnpm run update:axonivy:next && pnpm install --no-frozen-lockfile'
+            sh 'pnpm install && pnpm run update:axonivy:next'
             sh 'pnpm run package'
             dir ('playwright/process-test-project') {
               maven cmd: "-ntp verify -Dengine.page.url=${params.engineSource} -Dwebtest.cmd=webtest:${browser()}"

--- a/build/integration/inscription/Jenkinsfile
+++ b/build/integration/inscription/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
       steps {
         script {
           docker.build('node-webtest', '-f build/Dockerfile.playwright .').inside {
-            sh 'pnpm run update:axonivy:next && pnpm install --no-frozen-lockfile'
+            sh 'pnpm install && pnpm run update:axonivy:next'
             sh 'pnpm run package'
             dir ('playwright/inscription-test-project') {
               maven cmd: "-ntp verify -Dengine.page.url=${params.engineSource} -Dwebtest.cmd=webtest:inscription:${browser()}"
@@ -44,7 +44,7 @@ pipeline {
             docker.build('node', '-f build/Dockerfile.node .').inside {
               def branchName = env.BRANCH_NAME.replace("/", "%252F")
               sh '''
-                pnpm install --no-frozen-lockfile
+                pnpm install
                 pnpm run protocol:inscription clean
 
                 artifacts="https://jenkins.ivyteam.io/job/core_json-schema/job/'''+branchName+'''/lastSuccessfulBuild/artifact"

--- a/build/screenshot/Jenkinsfile
+++ b/build/screenshot/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
       steps {
         script {
           docker.build('node-webtest', '-f build/Dockerfile.playwright .').inside {
-            sh 'pnpm run update:axonivy:next && pnpm install --no-frozen-lockfile'
+            sh 'pnpm install && pnpm run update:axonivy:next'
             sh 'pnpm run package'
             dir ('playwright/process-test-project') {
               maven cmd: "-ntp verify -Dengine.page.url=${params.engineSource} -Dwebtest.cmd=webtest:screenshots:process"

--- a/integration/eclipse/package.json
+++ b/integration/eclipse/package.json
@@ -10,14 +10,14 @@
     "url": "https://github.com/axonivy/process-editor"
   },
   "dependencies": {
-    "@axonivy/jsonrpc": "~12.0.16-next.762.6b30854",
+    "@axonivy/jsonrpc": "next-12.0.16",
     "@axonivy/process-editor": "workspace:~",
     "@axonivy/process-editor-inscription": "workspace:~",
     "@axonivy/process-editor-inscription-protocol": "workspace:~",
     "@axonivy/process-editor-inscription-view": "workspace:~",
     "@axonivy/process-editor-protocol": "workspace:~",
-    "@axonivy/ui-components": "~12.0.16-next.762.6b30854",
-    "@axonivy/ui-icons": "~12.0.16-next.762.6b30854",
+    "@axonivy/ui-components": "next-12.0.16",
+    "@axonivy/ui-icons": "next-12.0.16",
     "@eclipse-glsp/client": "2.3.0",
     "@eclipse-glsp/ide": "2.3.0",
     "@eclipse-glsp/protocol": "2.3.0",

--- a/integration/inscription/package.json
+++ b/integration/inscription/package.json
@@ -9,12 +9,12 @@
     "url": "https://github.com/axonivy/process-editor"
   },
   "dependencies": {
-    "@axonivy/jsonrpc": "~12.0.16-next.762.6b30854",
+    "@axonivy/jsonrpc": "next-12.0.16",
     "@axonivy/process-editor-inscription-core": "workspace:~",
     "@axonivy/process-editor-inscription-protocol": "workspace:~",
     "@axonivy/process-editor-inscription-view": "workspace:~",
-    "@axonivy/ui-components": "~12.0.16-next.762.6b30854",
-    "@axonivy/ui-icons": "~12.0.16-next.762.6b30854",
+    "@axonivy/ui-components": "next-12.0.16",
+    "@axonivy/ui-icons": "next-12.0.16",
     "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-query-devtools": "^5.100.14",
     "vscode-jsonrpc": "8.2.1"

--- a/integration/standalone/package.json
+++ b/integration/standalone/package.json
@@ -10,14 +10,14 @@
     "url": "https://github.com/axonivy/process-editor"
   },
   "dependencies": {
-    "@axonivy/jsonrpc": "~12.0.16-next.762.6b30854",
+    "@axonivy/jsonrpc": "next-12.0.16",
     "@axonivy/process-editor": "workspace:~",
     "@axonivy/process-editor-inscription": "workspace:~",
     "@axonivy/process-editor-inscription-protocol": "workspace:~",
     "@axonivy/process-editor-inscription-view": "workspace:~",
     "@axonivy/process-editor-protocol": "workspace:~",
-    "@axonivy/ui-components": "~12.0.16-next.762.6b30854",
-    "@axonivy/ui-icons": "~12.0.16-next.762.6b30854",
+    "@axonivy/ui-components": "next-12.0.16",
+    "@axonivy/ui-icons": "next-12.0.16",
     "@eclipse-glsp/client": "2.3.0",
     "@eclipse-glsp/protocol": "2.3.0",
     "@tanstack/react-query": "^5.100.14",

--- a/integration/viewer/package.json
+++ b/integration/viewer/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@axonivy/process-editor": "workspace:~",
     "@axonivy/process-editor-protocol": "workspace:~",
-    "@axonivy/ui-components": "~12.0.16-next.762.6b30854",
-    "@axonivy/ui-icons": "~12.0.16-next.762.6b30854",
+    "@axonivy/ui-components": "next-12.0.16",
+    "@axonivy/ui-icons": "next-12.0.16",
     "@eclipse-glsp/client": "2.3.0",
     "@eclipse-glsp/protocol": "2.3.0",
     "inversify": "^6.2.2"

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "test": "vitest test",
     "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=report.xml",
     "webtest": "pnpm run --filter @axonivy/process-editor-playwright webtest",
-    "update:axonivy:next": "npx --yes npm-check-updates @axonivy* -w -c 0 -t semver -u",
+    "update:axonivy:next": "pnpm update -r @axonivy",
     "raise:version": "lerna version --no-git-tag-version --no-push --ignore-scripts --exact --yes",
-    "publish:next": "lerna publish --exact --canary --preid next --pre-dist-tag next --no-git-tag-version --no-push --ignore-scripts --yes"
+    "publish:next": "lerna publish --exact --canary --preid next --pre-dist-tag next-12.0.16 --no-git-tag-version --no-push --ignore-scripts --yes"
   },
   "devDependencies": {
-    "@axonivy/eslint-config": "~12.0.16-next.762.6b30854",
+    "@axonivy/eslint-config": "next-12.0.16",
     "@lerna-lite/cli": "^4.11.5",
     "@lerna-lite/publish": "^4.11.5",
     "@lerna-lite/run": "^4.11.5",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -32,7 +32,7 @@
     "sprotty": "^1.4.0"
   },
   "devDependencies": {
-    "@axonivy/ui-icons": "~12.0.16-next.762.6b30854",
+    "@axonivy/ui-icons": "next-12.0.16",
     "@types/toastify-js": "^1.12.4",
     "happy-dom": "^20.9.0",
     "inversify": "^6.2.2",

--- a/packages/inscription-core/package.json
+++ b/packages/inscription-core/package.json
@@ -24,7 +24,7 @@
     "@axonivy/jsonrpc": "~12.0.16-next"
   },
   "devDependencies": {
-    "@axonivy/jsonrpc": "~12.0.16-next.762.6b30854"
+    "@axonivy/jsonrpc": "next-12.0.16"
   },
   "type": "module",
   "types": "lib/index",

--- a/packages/inscription-view/package.json
+++ b/packages/inscription-view/package.json
@@ -35,8 +35,8 @@
     "react": "^18.2 || ^19.0"
   },
   "devDependencies": {
-    "@axonivy/ui-components": "~12.0.16-next.762.6b30854",
-    "@axonivy/ui-icons": "~12.0.16-next.762.6b30854",
+    "@axonivy/ui-components": "next-12.0.16",
+    "@axonivy/ui-icons": "next-12.0.16",
     "@tanstack/eslint-plugin-query": "5.101.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/inscription/package.json
+++ b/packages/inscription/package.json
@@ -29,8 +29,8 @@
     "react-aria": "^3.38"
   },
   "devDependencies": {
-    "@axonivy/jsonrpc": "~12.0.16-next.762.6b30854",
-    "@axonivy/ui-icons": "~12.0.16-next.762.6b30854",
+    "@axonivy/jsonrpc": "next-12.0.16",
+    "@axonivy/ui-icons": "next-12.0.16",
     "@types/react": "^18.3.29",
     "@types/react-dom": "^18.3.7",
     "monaco-languageclient": "^6.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   .:
     devDependencies:
       '@axonivy/eslint-config':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854(typescript@5.9.3)
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d(typescript@5.9.3)
       '@lerna-lite/cli':
         specifier: ^4.11.5
         version: 4.11.5(@lerna-lite/publish@4.11.5)(@lerna-lite/run@4.11.5)(@lerna-lite/version@4.11.5)(@types/node@24.13.0)
@@ -51,8 +51,8 @@ importers:
   integration/eclipse:
     dependencies:
       '@axonivy/jsonrpc':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@axonivy/process-editor':
         specifier: workspace:~
         version: link:../../packages/editor
@@ -69,11 +69,11 @@ importers:
         specifier: workspace:~
         version: link:../../packages/protocol
       '@axonivy/ui-components':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854(@axonivy/ui-icons@12.0.16-next.762.6b30854)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d(@axonivy/ui-icons@12.0.16-next.772.7889a2d)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@axonivy/ui-icons':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@eclipse-glsp/client':
         specifier: 2.3.0
         version: 2.3.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
@@ -109,8 +109,8 @@ importers:
   integration/inscription:
     dependencies:
       '@axonivy/jsonrpc':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@axonivy/process-editor-inscription-core':
         specifier: workspace:~
         version: link:../../packages/inscription-core
@@ -121,11 +121,11 @@ importers:
         specifier: workspace:~
         version: link:../../packages/inscription-view
       '@axonivy/ui-components':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854(@axonivy/ui-icons@12.0.16-next.762.6b30854)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d(@axonivy/ui-icons@12.0.16-next.772.7889a2d)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@axonivy/ui-icons':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@tanstack/react-query':
         specifier: ^5.100.14
         version: 5.101.0(react@18.3.1)
@@ -167,8 +167,8 @@ importers:
   integration/standalone:
     dependencies:
       '@axonivy/jsonrpc':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@axonivy/process-editor':
         specifier: workspace:~
         version: link:../../packages/editor
@@ -185,11 +185,11 @@ importers:
         specifier: workspace:~
         version: link:../../packages/protocol
       '@axonivy/ui-components':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854(@axonivy/ui-icons@12.0.16-next.762.6b30854)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d(@axonivy/ui-icons@12.0.16-next.772.7889a2d)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@axonivy/ui-icons':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@eclipse-glsp/client':
         specifier: 2.3.0
         version: 2.3.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
@@ -231,11 +231,11 @@ importers:
         specifier: workspace:~
         version: link:../../packages/protocol
       '@axonivy/ui-components':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854(@axonivy/ui-icons@12.0.16-next.762.6b30854)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d(@axonivy/ui-icons@12.0.16-next.772.7889a2d)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@axonivy/ui-icons':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@eclipse-glsp/client':
         specifier: 2.3.0
         version: 2.3.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
@@ -293,8 +293,8 @@ importers:
         version: 8.2.1
     devDependencies:
       '@axonivy/ui-icons':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@types/toastify-js':
         specifier: ^1.12.4
         version: 1.12.4
@@ -351,11 +351,11 @@ importers:
         version: 3.49.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@axonivy/jsonrpc':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@axonivy/ui-icons':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@types/react':
         specifier: ^18.3.29
         version: 18.3.30
@@ -391,8 +391,8 @@ importers:
         version: 3.18.0
     devDependencies:
       '@axonivy/jsonrpc':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
 
   packages/inscription-protocol:
     devDependencies:
@@ -446,11 +446,11 @@ importers:
         version: 4.1.2(react@18.3.1)
     devDependencies:
       '@axonivy/ui-components':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854(@axonivy/ui-icons@12.0.16-next.762.6b30854)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d(@axonivy/ui-icons@12.0.16-next.772.7889a2d)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@axonivy/ui-icons':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@tanstack/eslint-plugin-query':
         specifier: 5.101.0
         version: 5.101.0(eslint@9.39.4)(typescript@5.9.3)
@@ -512,20 +512,20 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@axonivy/eslint-config@12.0.16-next.762.6b30854':
-    resolution: {integrity: sha512-KiUDwGG6b1Sb3bJJ1AQ7c7VP6CQLeOgvrlNlAaD6ylslNy9r9eQSiI3Pt5TjFth5ZN2E11M4lSjfND1PO+VWOA==}
+  '@axonivy/eslint-config@12.0.16-next.772.7889a2d':
+    resolution: {integrity: sha512-LsT+DVsFh6nVq+TYQj/n6jiYmmyxexorGzGIrTX5Ei1HhRi+5PjP5X2mcXYh0WTxh37WRCgiT1rBZUjeuOBouw==}
 
-  '@axonivy/jsonrpc@12.0.16-next.762.6b30854':
-    resolution: {integrity: sha512-IN0XXN4237kZF6KJYx0BvINgjmjBFiOeBS3bUXgosQoUqdcJ+4HhZGJN51hrhHlghmGx/o9OUcQzYGcQEImCZA==}
+  '@axonivy/jsonrpc@12.0.16-next.772.7889a2d':
+    resolution: {integrity: sha512-BAb5mWs8uk0pfQ7a8dvbEMIpivf4Xt2n9nTkDHva8Oi7XBvgodo7xeihkcWydzyhootgxjUdwr6LCy5zm5evFg==}
 
-  '@axonivy/ui-components@12.0.16-next.762.6b30854':
-    resolution: {integrity: sha512-IspGyWPGpjNGMgpMWPyRU25thI8wt3gV7/7a5J2siRv5NCSC1DWxVGhmR79BUtNB7uFuDyMFHH4S8glZcwJPng==}
+  '@axonivy/ui-components@12.0.16-next.772.7889a2d':
+    resolution: {integrity: sha512-Q7eOumP74Tntrn+14+wTRWE70/BowLGA0/DfBsvZDzwAXUjLur039aOh8wihfhFx6YWEQb9rPv1ZFMk7NsXHrQ==}
     peerDependencies:
       '@axonivy/ui-icons': ~12.0.16-next
       react: ^18.2 || ^19.0
 
-  '@axonivy/ui-icons@12.0.16-next.762.6b30854':
-    resolution: {integrity: sha512-WQ1tIh/iYb87ZU1Ds13IOWpf1QRGZkQ2V57wg5ubVtxoml3u4q+ivzED7p2kLOFRKumtduwdxKTm4UgZ/jvFDQ==}
+  '@axonivy/ui-icons@12.0.16-next.772.7889a2d':
+    resolution: {integrity: sha512-/DcIbverUgoWKRFhTPIKqXA+z5zBH64bDV2vZwUaTRjGGsMnYgnOCUwQg5t7giv7F3aA2vwki8y8R9B/3NKSpQ==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1725,8 +1725,8 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@react-aria/dnd@3.12.0':
-    resolution: {integrity: sha512-FqAaxIMCgpq83UQhJRpSR+o3K4XQQYbJMKxhBWGL84Wn1p6m8QmWGvRKAiHeUoQXlY8R6KNxlMR/KjJvV8/lBA==}
+  '@react-aria/dnd@3.12.1':
+    resolution: {integrity: sha512-gAFsHChr2K9enfTOyY3h+7c+hb8fM7GGSWRlcE63If+jrdBRPicQ0wyiRr1ChFU3KVH3Nk2PZUUMET58QlUYVQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -1926,8 +1926,8 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
-  '@tanstack/eslint-plugin-query@5.100.11':
-    resolution: {integrity: sha512-4JfaSf6/ql9AFAsRWaWulz40gS86bDgSr15pWCI3o+oX3sdZ0ZR8AOeNrCEqyIrV6wFxnCfhFi1kWjOlZ+66Ew==}
+  '@tanstack/eslint-plugin-query@5.100.14':
+    resolution: {integrity: sha512-NbpiBCmeHTRuVHeV5+U+1bzmxyTW5Dzp2sCeE6Hx+ZJTJWFK9dsm8VZmRc7LQP9/ZORsF620PvgUk67AwiBo4A==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ^5.4.0 || ^6.0.0
@@ -2093,16 +2093,16 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript-eslint/eslint-plugin@8.59.4':
-    resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
+  '@typescript-eslint/eslint-plugin@8.60.0':
+    resolution: {integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.59.4
+      '@typescript-eslint/parser': ^8.60.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.59.4':
-    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
+  '@typescript-eslint/parser@8.60.0':
+    resolution: {integrity: sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -2114,8 +2114,18 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.60.0':
+    resolution: {integrity: sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.59.4':
     resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.60.0':
+    resolution: {integrity: sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.59.4':
@@ -2124,8 +2134,14 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/type-utils@8.59.4':
-    resolution: {integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==}
+  '@typescript-eslint/tsconfig-utils@8.60.0':
+    resolution: {integrity: sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.60.0':
+    resolution: {integrity: sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -2135,8 +2151,18 @@ packages:
     resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.60.0':
+    resolution: {integrity: sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.59.4':
     resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.60.0':
+    resolution: {integrity: sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2148,8 +2174,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.60.0':
+    resolution: {integrity: sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.59.4':
     resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.60.0':
+    resolution: {integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-react@4.7.0':
@@ -3943,12 +3980,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-aria@3.48.0:
-    resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   react-aria@3.49.0:
     resolution: {integrity: sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==}
     peerDependencies:
@@ -3965,8 +3996,8 @@ packages:
     peerDependencies:
       react: '>=16.13.1'
 
-  react-hotkeys-hook@4.6.1:
-    resolution: {integrity: sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==}
+  react-hotkeys-hook@4.6.2:
+    resolution: {integrity: sha512-FmP+ZriY3EG59Ug/lxNfrObCnW9xQShgk7Nb83+CkpfkcCpfS95ydv+E9JuXA5cp8KtskU7LGlIARpkc92X22Q==}
     peerDependencies:
       react: '>=16.8.1'
       react-dom: '>=16.8.1'
@@ -4009,11 +4040,6 @@ packages:
     peerDependencies:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-
-  react-stately@3.46.0:
-    resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   react-stately@3.47.0:
     resolution: {integrity: sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==}
@@ -4391,6 +4417,7 @@ packages:
   tsconfck@3.1.1:
     resolution: {integrity: sha512-00eoI6WY57SvZEVjm13stEVE90VkEdJAFGgpFLTsZbJyW/LwFQ7uQxJHWpZ2hzSWgCPKc9AnBnNP+0X7o3hAmQ==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -4438,8 +4465,8 @@ packages:
     peerDependencies:
       typescript: '>=4.2.3'
 
-  typescript-eslint@8.59.4:
-    resolution: {integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==}
+  typescript-eslint@8.60.0:
+    resolution: {integrity: sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -4857,12 +4884,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
-  '@axonivy/eslint-config@12.0.16-next.762.6b30854(typescript@5.9.3)':
+  '@axonivy/eslint-config@12.0.16-next.772.7889a2d(typescript@5.9.3)':
     dependencies:
       '@eslint/js': 9.39.4
-      '@tanstack/eslint-plugin-query': 5.100.11(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      '@tanstack/eslint-plugin-query': 5.100.14(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       eslint-formatter-checkstyle: 8.40.0
       eslint-plugin-playwright: 2.10.4(eslint@9.39.4)
@@ -4870,19 +4897,20 @@ snapshots:
       eslint-plugin-react-compiler: 19.1.0-rc.2(eslint@9.39.4)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4)
       eslint-plugin-testing-library: 7.16.2(eslint@9.39.4)(typescript@5.9.3)
-      typescript-eslint: 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      globals: 17.5.0
+      typescript-eslint: 8.60.0(eslint@9.39.4)(typescript@5.9.3)
     transitivePeerDependencies:
       - jiti
       - supports-color
       - typescript
 
-  '@axonivy/jsonrpc@12.0.16-next.762.6b30854':
+  '@axonivy/jsonrpc@12.0.16-next.772.7889a2d':
     dependencies:
       vscode-jsonrpc: 8.2.1
 
-  '@axonivy/ui-components@12.0.16-next.762.6b30854(@axonivy/ui-icons@12.0.16-next.762.6b30854)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@axonivy/ui-components@12.0.16-next.772.7889a2d(@axonivy/ui-icons@12.0.16-next.772.7889a2d)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@axonivy/ui-icons': 12.0.16-next.762.6b30854
+      '@axonivy/ui-icons': 12.0.16-next.772.7889a2d
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4897,12 +4925,12 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/dnd': 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/dnd': 3.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table': 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       downshift: 9.0.13(react@18.3.1)
       react: 18.3.1
-      react-hotkeys-hook: 4.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-hotkeys-hook: 4.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-resizable-panels: 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner: 1.7.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
@@ -4910,7 +4938,7 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
-  '@axonivy/ui-icons@12.0.16-next.762.6b30854': {}
+  '@axonivy/ui-icons@12.0.16-next.772.7889a2d': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -6310,12 +6338,12 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@react-aria/dnd@3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/dnd@3.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.35.0(react@18.3.1)
       '@swc/helpers': 0.5.23
       react: 18.3.1
-      react-aria: 3.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-aria: 3.49.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
 
   '@react-types/shared@3.35.0(react@18.3.1)':
@@ -6449,7 +6477,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tanstack/eslint-plugin-query@5.100.11(eslint@9.39.4)(typescript@5.9.3)':
+  '@tanstack/eslint-plugin-query@5.100.14(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
@@ -6621,14 +6649,14 @@ snapshots:
     dependencies:
       '@types/node': 24.13.0
 
-  '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.59.4
-      '@typescript-eslint/type-utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.4
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/type-utils': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
       eslint: 9.39.4
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -6637,12 +6665,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.4
-      '@typescript-eslint/types': 8.59.4
-      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.4
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       eslint: 9.39.4
       typescript: 5.9.3
@@ -6658,20 +6686,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.60.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.59.4':
     dependencies:
       '@typescript-eslint/types': 8.59.4
       '@typescript-eslint/visitor-keys': 8.59.4
 
+  '@typescript-eslint/scope-manager@8.60.0':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
+
   '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.59.4(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.60.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.59.4
-      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.60.0(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.4
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -6681,12 +6727,29 @@ snapshots:
 
   '@typescript-eslint/types@8.59.4': {}
 
+  '@typescript-eslint/types@8.60.0': {}
+
   '@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.59.4(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
       '@typescript-eslint/types': 8.59.4
       '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.60.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -6707,9 +6770,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.60.0(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.59.4':
     dependencies:
       '@typescript-eslint/types': 8.59.4
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.60.0':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
 
   '@vitejs/plugin-react@4.7.0(vite@7.3.5(@types/node@25.9.2)(yaml@2.8.3))':
@@ -8728,20 +8807,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-aria@3.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@internationalized/date': 3.12.2
-      '@internationalized/number': 3.6.7
-      '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.35.0(react@18.3.1)
-      '@swc/helpers': 0.5.23
-      aria-hidden: 1.2.6
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-stately: 3.46.0(react@18.3.1)
-      use-sync-external-store: 1.6.0(react@18.3.1)
-
   react-aria@3.49.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@internationalized/date': 3.12.2
@@ -8767,7 +8832,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       react: 18.3.1
 
-  react-hotkeys-hook@4.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-hotkeys-hook@4.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -8803,16 +8868,6 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  react-stately@3.46.0(react@18.3.1):
-    dependencies:
-      '@internationalized/date': 3.12.2
-      '@internationalized/number': 3.6.7
-      '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.35.0(react@18.3.1)
-      '@swc/helpers': 0.5.23
-      react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
 
   react-stately@3.47.0(react@18.3.1):
     dependencies:
@@ -9344,12 +9399,12 @@ snapshots:
       tar: 7.5.15
       typescript: 5.9.3
 
-  typescript-eslint@8.59.4(eslint@9.39.4)(typescript@5.9.3):
+  typescript-eslint@8.60.0(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,3 +21,5 @@ publicHoistPattern:
 trustPolicy: no-downgrade
 trustPolicyIgnoreAfter: 43200 # minutes (30 days)
 verifyDepsBeforeRun: warn
+registries:
+  '@axonivy': 'https://npmjs-registry.ivyteam.ch/'


### PR DESCRIPTION
## What changed
- Replaced fixed Axon Ivy canary package specs with the `next-12.0.16` dist-tag and kept local workspace dependencies as `workspace:~`.
- Moved the Axon Ivy registry mapping from `.npmrc` into `pnpm-workspace.yaml`.
- Updated Ivy raise scripts and Jenkins pipelines to follow the dist-tag install/update flow.
- Refreshed `pnpm-lock.yaml` with the resolved dist-tag package versions.