### PR TITLE
chore: pnpm audit fix transient CVEs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  dompurify@>=3.1.3 <=3.3.1: '>=3.3.2'
+  dompurify@>=3.1.3 <=3.4.10: '>=3.4.11'
   lodash@<=4.17.23: '>=4.18.0'
   typescript-cp>tar: '>=7.5.11'
   uuid@<14.0.0: '>=14.0.0'
@@ -247,8 +247,8 @@ importers:
         specifier: ^8.20
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       dompurify:
-        specifier: ^3.4.9
-        version: 3.4.9
+        specifier: '>=3.4.11'
+        version: 3.4.11
       i18next:
         specifier: ^25.0.0 || ^26.0.0
         version: 26.3.1(typescript@6.0.3)
@@ -403,8 +403,8 @@ importers:
         specifier: ^3.14.2
         version: 3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       dompurify:
-        specifier: ^3.4.9
-        version: 3.4.9
+        specifier: '>=3.4.11'
+        version: 3.4.11
       downshift:
         specifier: ^9.0
         version: 9.0.13(react@19.2.7)
@@ -2562,8 +2562,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -6602,7 +6602,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7503,7 +7503,7 @@ snapshots:
 
   monaco-editor@0.55.1(patch_hash=899da2f303ca4825b0017a43537473be707dba57c101f26ff4a9aea957f2351f):
     dependencies:
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       marked: 14.0.0
 
   ms@2.1.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - '@axonivy/*'
 overrides:
-  dompurify@>=3.1.3 <=3.3.1: '>=3.3.2'
+  dompurify@>=3.1.3 <=3.4.10: '>=3.4.11'
   lodash@<=4.17.23: '>=4.18.0'
   typescript-cp>tar: '>=7.5.11'
   uuid@<14.0.0: '>=14.0.0'


### PR DESCRIPTION
## Summary
- Baseline audit status: 1 CVE
- Final audit status: 0 CVEs
- Files changed: pnpm-lock.yaml, pnpm-workspace.yaml
- Remaining unresolved CVEs: none

## Details
- Updates the dompurify override to force vulnerable versions <=3.4.10 to resolve to >=3.4.11.
- Resolves GHSA-cmwh-pvxp-8882 for dompurify.

## Verification
- pnpm -C /Users/lli/GitWorkspace/process-editor/process-editor-master install --frozen-lockfile
- pnpm -C /Users/lli/GitWorkspace/process-editor/process-editor-master audit --json